### PR TITLE
chore: audit open-looper repo, skills, and agents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ git log --grep="Loop-Phase:" --oneline
 
 ## Guidelines
 
-- Agents spawn subagents via `Task` tool, not inline execution
+- Agents spawn subagents via `claude-spawn-agent` Bash command, not inline execution
 - All work happens in worktrees, never on default branch
 - Use conventional commits with loop trailers
 - Test changes before committing


### PR DESCRIPTION
## Summary
- Audit of open-looper repository, looper skill, and all agents
- Added `mode: subagent` to 13 helper agents missing it
- Removed unused `Todowrite` tool from SKILL.md
- Fixed `Task` vs `claude-spawn-agent` inconsistency across SKILL.md and CONTRIBUTING.md

## Changes
- 14/14 agents now have proper `mode` field
- SKILL.md tools list cleaned up
- Agent spawning mechanism documented consistently