### PR TITLE
feat(looper): make CI check and merge strategy explicit in skill flow

### DIFF
--- a/.opencode/skills/looper/SKILL.md
+++ b/.opencode/skills/looper/SKILL.md
@@ -116,14 +116,37 @@ eval "$SYNC_OUTPUT"
 ```
 
 - **`STATUS=up-to-date` or `STATUS=rebased` (exit 0):** Continue to step 5.
-- **`STATUS=conflicts` (exit 1):** The rebase is paused with conflicts. Resolve them:
-  1. List conflicted files: `git diff --name-only --diff-filter=U`
-  2. Read each conflicted file, understand both sides of the conflict.
-  3. Edit the file to resolve the conflict (remove conflict markers, keep correct code).
-  4. Stage each resolved file: `git add <file>`
-  5. Continue the rebase: `git rebase --continue`
-  6. If new conflicts appear, repeat until the rebase completes.
+- **`STATUS=conflicts` (exit 1):** The rebase is paused with conflicts. Resolve them using the **"prefer local changes"** strategy (see below).
 - **Exit 2 (error):** Warn and continue — the loop can still proceed without sync.
+
+**Capture sync state for step 7:**
+
+```bash
+SYNC_STATUS="${STATUS:-}"
+SYNC_HEAD=$(git rev-parse HEAD)
+```
+
+> **Conflict resolution strategy: prefer local (worktree) changes**
+>
+> When resolving rebase conflicts, prefer keeping your local changes (the worktree branch).
+> This is because the worktree branch contains the planned implementation, while the
+> remote branch is the shared baseline.
+>
+> For each conflicted file:
+> 1. Read the file to understand both sides of the conflict
+> 2. Use `git checkout --ours <file>` to keep your loop/ branch version (the "ours" side)
+> 3. Stage the resolved file: `git add <file>`
+> 4. Continue the rebase: `git rebase --continue`
+>
+> If new conflicts appear, repeat until the rebase completes.
+>
+> **Why prefer local?** The looper worktree is a disposable context for implementing
+> a fix. The remote baseline is the source of truth. Preferring local ensures the
+> planned changes are preserved.
+>
+> **Alternative (not recommended):** To prefer remote changes instead, use
+> `git checkout --theirs <file>` before `git add`. This discards local changes
+> and is generally not what you want in a loop/ worktree.
 
 ### 4c. Fetch issue context (if referenced)
 
@@ -235,19 +258,92 @@ VERDICT=$(git log --grep="Loop-Verdict:" -1 --format="%B" \
 - **PASS:** Break out of the loop, proceed to step 7.
 - **FAIL** (or no verdict): Continue to next iteration.
 
-### 7. Sync before PR
+### 7. Sync before PR (conditional)
 
 ```bash
-SYNC_OUTPUT=$($SCRIPTS_DIR/sync-with-remote) && SYNC_EXIT=0 || SYNC_EXIT=$?
-eval "$SYNC_OUTPUT"
+# Check if we need to re-sync:
+# 1. Did step 4b succeed with up-to-date or rebased?
+# 2. Are there new commits since step 4b?
+
+STEP4B_STATUS="${SYNC_STATUS:-}"
+STEP4B_HEAD="${SYNC_HEAD:-}"
+
+CURRENT_HEAD=$(git rev-parse HEAD)
+NEW_COMMITS=false
+
+if [ "$STEP4B_STATUS" = "up-to-date" ] || [ "$STEP4B_STATUS" = "rebased" ]; then
+    if [ "$CURRENT_HEAD" != "$STEP4B_HEAD" ]; then
+        NEW_COMMITS=true
+    fi
+fi
+
+if [ "$NEW_COMMITS" = true ]; then
+    echo "New commits detected — re-syncing with remote..."
+    SYNC_OUTPUT=$($SCRIPTS_DIR/sync-with-remote) && SYNC_EXIT=0 || SYNC_EXIT=$?
+    eval "$SYNC_OUTPUT"
+    # Handle conflicts using "prefer local" strategy (see step 4b)
+else
+    echo "No new commits since step 4b — skipping re-sync."
+fi
 ```
 
-Resolve any conflicts as in step 4b.
+**Never skip if step 4b had conflicts** — if `STEP4B_STATUS=conflicts`, always run the re-sync
+to allow resolution to proceed.
 
 ### 8. Report results and create PR
 
 - **PASS:** Report success with iteration count. Then invoke the `create-github-pr` skill to push the branch and create a PR.
 - **FAIL (max iterations):** Report failure. The worktree is preserved for debugging.
+
+### 8a. Wait for CI
+
+After creating the PR, poll until CI checks complete.
+
+```bash
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+CI_STATUS=$(gh pr checks "$PR_NUMBER" --watch 2>&1) || CI_EXIT=$?
+```
+
+- **All checks pass:** Proceed to step 8b.
+- **Any check fails:** Report failure. Do NOT proceed to merge. Exit with error.
+- **Timeout (>20 min):** Report timeout. Do NOT proceed to merge. Exit with error.
+- **No checks configured:** Log "No CI checks configured" and proceed to step 8b.
+
+### 8b. Detect DB migrations
+
+Before merge, check whether the PR contains DB migration files:
+
+```bash
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+HAS_MIGRATIONS=false
+
+if echo "$CHANGED_FILES" | grep -qiE \
+    '(migrations?/|db/migrate|alembic/versions|flyway|prisma/migrations|drizzle/|knex/migrations|sequelize/migrations|typeorm/migrations|migrate.*\.sql$|migration.*\.sql$)'; then
+    HAS_MIGRATIONS=true
+fi
+```
+
+Migration patterns detected:
+- `migrations/` or `migration/` — generic migration directories
+- `db/migrate/` — Rails ActiveRecord migrations
+- `alembic/versions/` — Python/Alembic migrations
+- `prisma/migrations/` — Prisma ORM migrations
+- `drizzle/` — Drizzle ORM migration files
+- `knex/migrations/`, `sequelize/migrations/`, `typeorm/migrations/` — other ORMs
+- `flyway/` — Flyway SQL migrations
+- Files matching `migrate*.sql` or `migration*.sql`
+
+### 8c. Merge or leave open
+
+```bash
+if [ "$HAS_MIGRATIONS" = true ]; then
+    echo "DB migrations detected — leaving PR open for manual review."
+    echo "Merge manually when ready: gh pr merge $PR_NUMBER --squash --delete-branch"
+else
+    # Proceed to create-github-pr for squash-merge (with --skip-db-check since we already checked)
+    invoke create-github-pr skill with --skip-db-check
+fi
+```
 
 ### 9. Clean up
 

--- a/.opencode/skills/looper/tests/test-skill-changes.sh
+++ b/.opencode/skills/looper/tests/test-skill-changes.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Tests for looper skill changes in iteration 3:
+# - Issue 1: Step 8a (WAIT_FOR_CI)
+# - Issue 2: Step 8b (DB migration detection), Step 8c (merge or leave open)
+# - Issue 3: Step 7 conditional re-sync (SYNC_STATUS, SYNC_HEAD, NEW_COMMITS)
+# - Issue 4: Conflict resolution guidance ("prefer local" / "--ours")
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_MD="$SCRIPT_DIR/../SKILL.md"
+
+# -------------------------------------------------------------------
+# Issue 4: Conflict resolution guidance
+# -------------------------------------------------------------------
+
+echo "=== Test: conflict resolution guidance mentions 'prefer local' ==="
+if grep -q "prefer local" "$SKILL_MD"; then
+    echo "PASS: SKILL.md mentions 'prefer local' strategy"
+else
+    echo "FAIL: SKILL.md does not mention 'prefer local' strategy"
+    exit 1
+fi
+
+echo "=== Test: conflict resolution guidance mentions '--ours' ==="
+if grep -q '\-\-ours' "$SKILL_MD"; then
+    echo "PASS: SKILL.md mentions '--ours' for conflict resolution"
+else
+    echo "FAIL: SKILL.md does not mention '--ours' for conflict resolution"
+    exit 1
+fi
+
+echo "=== Test: conflict resolution guidance explains 'ours' means worktree branch ==="
+# The guidance should explain that "ours" = the loop/ branch, not incoming remote
+if grep -qE "ours.*(loop|worktree|branch)" "$SKILL_MD" || grep -qE "(loop|worktree|branch).*ours" "$SKILL_MD"; then
+    echo "PASS: SKILL.md explains 'ours' in context of worktree branch"
+else
+    echo "FAIL: SKILL.md does not explain 'ours' meaning worktree branch"
+    exit 1
+fi
+
+# -------------------------------------------------------------------
+# Issue 3: Step 7 conditional re-sync
+# -------------------------------------------------------------------
+
+echo "=== Test: SKILL.md captures SYNC_STATUS at end of step 4b ==="
+if grep -qE "SYNC_STATUS.*=" "$SKILL_MD"; then
+    echo "PASS: SKILL.md references SYNC_STATUS"
+else
+    echo "FAIL: SKILL.md does not capture SYNC_STATUS"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md captures SYNC_HEAD at end of step 4b ==="
+if grep -qE "SYNC_HEAD.*=" "$SKILL_MD"; then
+    echo "PASS: SKILL.md references SYNC_HEAD"
+else
+    echo "FAIL: SKILL.md does not capture SYNC_HEAD"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md references NEW_COMMITS variable ==="
+if grep -qE "NEW_COMMITS" "$SKILL_MD"; then
+    echo "PASS: SKILL.md references NEW_COMMITS"
+else
+    echo "FAIL: SKILL.md does not reference NEW_COMMITS"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 7 has conditional re-sync logic ==="
+# Step 7 should conditionally re-sync only if NEW_COMMITS=true
+# It should compare CURRENT_HEAD vs STEP4B_HEAD (or SYNC_HEAD)
+if grep -qE "NEW_COMMITS.*true|CURRENT_HEAD.*SYNC_HEAD" "$SKILL_MD"; then
+    echo "PASS: SKILL.md has conditional re-sync logic"
+else
+    echo "FAIL: SKILL.md missing conditional re-sync logic"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 7 skips re-sync when no new commits ==="
+if grep -qE "skip.*re.?sync|skipping.*re.?sync|No new commits" "$SKILL_MD"; then
+    echo "PASS: SKILL.md mentions skipping re-sync when no new commits"
+else
+    echo "FAIL: SKILL.md does not mention skipping re-sync"
+    exit 1
+fi
+
+# -------------------------------------------------------------------
+# Issue 1: Step 8a (WAIT_FOR_CI)
+# -------------------------------------------------------------------
+
+echo "=== Test: SKILL.md has step 8a 'Wait for CI' ==="
+if grep -qE "8a.*Wait for CI|Wait for CI" "$SKILL_MD"; then
+    echo "PASS: SKILL.md has step 8a Wait for CI"
+else
+    echo "FAIL: SKILL.md missing step 8a Wait for CI"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8a uses 'gh pr checks --watch' ==="
+if grep -qE "gh pr checks.*\-\-watch" "$SKILL_MD"; then
+    echo "PASS: SKILL.md uses 'gh pr checks --watch'"
+else
+    echo "FAIL: SKILL.md does not use 'gh pr checks --watch'"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8a handles CI failure ==="
+if grep -qE "CI fails|Check fails|fail.*CI|failure" "$SKILL_MD"; then
+    echo "PASS: SKILL.md handles CI failure"
+else
+    echo "FAIL: SKILL.md does not handle CI failure"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8a handles CI timeout ==="
+if grep -qE "timeout|time.?out" "$SKILL_MD"; then
+    echo "PASS: SKILL.md handles CI timeout"
+else
+    echo "FAIL: SKILL.md does not handle CI timeout"
+    exit 1
+fi
+
+# -------------------------------------------------------------------
+# Issue 2: Step 8b (DB migration detection)
+# -------------------------------------------------------------------
+
+echo "=== Test: SKILL.md has step 8b 'Detect DB migrations' ==="
+if grep -qE "8b.*Detect|Detect DB migrations|DB migrations detected" "$SKILL_MD"; then
+    echo "PASS: SKILL.md has step 8b Detect DB migrations"
+else
+    echo "FAIL: SKILL.md missing step 8b Detect DB migrations"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8b checks for migration file patterns ==="
+# Should check for patterns like migrations/, db/migrate, alembic/versions, etc.
+if grep -qE "migrations?/|db/migrate|alembic/versions|prisma/migrations|drizzle/" "$SKILL_MD"; then
+    echo "PASS: SKILL.md checks for migration file patterns"
+else
+    echo "FAIL: SKILL.md does not check migration file patterns"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md has step 8c 'Merge or leave open' ==="
+if grep -qE "8c.*Merge|Merge or leave|leave.*open" "$SKILL_MD"; then
+    echo "PASS: SKILL.md has step 8c Merge or leave open"
+else
+    echo "FAIL: SKILL.md missing step 8c Merge or leave open"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8c leaves PR open when migrations detected ==="
+if grep -qE "HAS_MIGRATIONS.*true|leaving.*open|leave.*open" "$SKILL_MD"; then
+    echo "PASS: SKILL.md leaves PR open when migrations detected"
+else
+    echo "FAIL: SKILL.md does not leave PR open when migrations detected"
+    exit 1
+fi
+
+echo "=== Test: SKILL.md step 8c proceeds with merge when no migrations ==="
+# Should proceed to merge/squash when no migrations
+if grep -qE "no.*migrations|skip.*merge|squash.*merge" "$SKILL_MD"; then
+    echo "PASS: SKILL.md proceeds with merge when no migrations"
+else
+    echo "FAIL: SKILL.md does not proceed with merge when no migrations"
+    exit 1
+fi
+
+# -------------------------------------------------------------------
+# All tests passed
+# -------------------------------------------------------------------
+echo ""
+echo "=== All tests passed ==="
+exit 0

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,216 @@
+# SPEC.md — looper skill: make CI check and merge strategy explicit
+
+## Goal
+
+After Checker issues PASS, the looper skill must expose CI polling and DB-migration-aware merge strategy as **explicit phases** in the skill flow, not hidden inside the create-github-pr skill. The goal is visibility and control within the looper loop itself.
+
+---
+
+## Issue 1: Add explicit WAIT_FOR_CI phase to skill flow
+
+**Problem:** CI polling is buried inside create-github-pr (Phase 5). The looper skill should have an explicit WAIT_FOR_CI phase so that:
+- The loop does not exit until CI results are known
+- Failure to pass CI is surfaced before attempting merge
+- The user gets clear feedback on CI status
+
+**Acceptance Criteria:**
+- [ ] After step 8 (create PR), there is a new step 8a called "Wait for CI"
+- [ ] Step 8a invokes CI polling directly (not via create-github-pr), using `gh pr checks --watch`
+- [ ] If CI fails, the skill reports failure and does NOT proceed to merge
+- [ ] If CI times out (>20 min), the skill reports timeout and does NOT proceed to merge
+- [ ] Only after CI passes does the flow proceed to step 8b (merge decision)
+
+**Implementation Detail:**
+```bash
+### 8a. Wait for CI
+
+After creating the PR, poll until CI checks complete.
+
+```bash
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+CI_STATUS=$(gh pr checks $PR_NUMBER --watch 2>&1) || CI_EXIT=$?
+```
+
+- **All checks pass:** Proceed to step 8b.
+- **Any check fails:** Report failure. Do NOT proceed to merge. Exit with error.
+- **Timeout (>20 min):** Report timeout. Do NOT proceed to merge. Exit with error.
+- **No checks configured:** Log "No CI checks configured" and proceed to step 8b.
+```
+
+---
+
+## Issue 2: Make DB migration detection part of looper skill
+
+**Problem:** DB migration detection (Phase 6a in create-github-pr) is only in create-github-pr. The looper skill should also detect DB migrations so it can make the merge-or-leave-open decision itself, rather than delegating entirely to create-github-pr.
+
+**Acceptance Criteria:**
+- [ ] Step 8b (merge decision) is in the looper skill, not deferred to create-github-pr
+- [ ] Before calling create-github-pr, the looper skill checks for DB migrations in the changeset
+- [ ] If DB migrations are detected, the looper skill leaves the PR open and reports the reason
+- [ ] If no DB migrations, the looper skill proceeds with squash-merge via create-github-pr
+- [ ] The DB migration detection patterns are the same as in create-github-pr (shared logic or re-implemented)
+
+**Implementation Detail:**
+```bash
+### 8b. Detect DB migrations
+
+Before merge, check whether the PR contains DB migration files:
+
+```bash
+CHANGED_FILES=$(git diff --name-only "$BASE_REF"...HEAD)
+HAS_MIGRATIONS=false
+
+if echo "$CHANGED_FILES" | grep -qiE \
+    '(migrations?/|db/migrate|alembic/versions|flyway|prisma/migrations|drizzle/|knex/migrations|sequelize/migrations|typeorm/migrations|migrate.*\.sql$|migration.*\.sql$)'; then
+    HAS_MIGRATIONS=true
+fi
+```
+
+Migration patterns detected:
+- `migrations/` or `migration/` — generic migration directories
+- `db/migrate/` — Rails ActiveRecord migrations
+- `alembic/versions/` — Python/Alembic migrations
+- `prisma/migrations/` — Prisma ORM migrations
+- `drizzle/` — Drizzle ORM migration files
+- `knex/migrations/`, `sequelize/migrations/`, `typeorm/migrations/` — other ORMs
+- `flyway/` — Flyway SQL migrations
+- Files matching `migrate*.sql` or `migration*.sql`
+
+### 8c. Merge or leave open
+
+```bash
+if [ "$HAS_MIGRATIONS" = true ]; then
+    echo "DB migrations detected — leaving PR open for manual review."
+    echo "Merge manually when ready: gh pr merge $PR_NUMBER --squash --delete-branch"
+else
+    # Proceed to create-github-pr for squash-merge
+    invoke create-github-pr skill with --skip-db-check
+fi
+```
+```
+
+---
+
+## Issue 3: Simplify step 7 — skip re-sync if no new commits since step 4b
+
+**Problem:** Step 7 always runs `sync-with-remote`, but if step 4b already succeeded with `STATUS=up-to-date` or `STATUS=rebased` and no new commits were made since then, the re-sync is redundant.
+
+**Acceptance Criteria:**
+- [ ] Step 4b captures `SYNC_STATUS` (up-to-date, rebased, or conflicts)
+- [ ] Step 7 checks: if `SYNC_STATUS` was `up-to-date` or `rebased` AND no new commits exist on the branch, skip the re-sync entirely
+- [ ] A new helper script or inline check compares current HEAD vs the HEAD at step 4b completion
+- [ ] Only if there are new commits (e.g., from the doer's work) does step 7 run the rebase
+
+**Implementation Detail:**
+```bash
+### 7. Sync before PR (conditional)
+
+```bash
+# Check if we need to re-sync:
+# 1. Did step 4b succeed with up-to-date or rebased?
+# 2. Are there new commits since step 4b?
+
+STEP4B_STATUS="${SYNC_STATUS:-}"
+STEP4B_HEAD="${SYNC_HEAD:-}"  # captured at end of step 4b
+
+CURRENT_HEAD=$(git rev-parse HEAD)
+NEW_COMMITS=false
+
+if [ "$STEP4B_STATUS" = "up-to-date" ] || [ "$STEP4B_STATUS" = "rebased" ]; then
+    if [ "$CURRENT_HEAD" != "$STEP4B_HEAD" ]; then
+        NEW_COMMITS=true
+    fi
+fi
+
+if [ "$NEW_COMMITS" = true ]; then
+    echo "New commits detected — re-syncing with remote..."
+    SYNC_OUTPUT=$($SCRIPTS_DIR/sync-with-remote) && SYNC_EXIT=0 || SYNC_EXIT=$?
+    eval "$SYNC_OUTPUT"
+    # Handle conflicts as in step 4b
+else
+    echo "No new commits since step 4b — skipping re-sync."
+fi
+```
+```
+
+**Capture at end of step 4b:**
+```bash
+SYNC_STATUS="${STATUS:-}"
+SYNC_HEAD=$(git rev-parse HEAD)
+# Export these for use in step 7 (via environment or tempfile)
+```
+
+---
+
+## Issue 4: Add conflict resolution guidance (prefer local or remote?)
+
+**Problem:** Step 4b and step 7 conflict resolution provides no guidance on whether to prefer local changes or remote changes when resolving conflicts.
+
+**Acceptance Criteria:**
+- [ ] Conflict resolution in step 4b and step 7 specifies "prefer local changes" as the default strategy
+- [ ] The guidance explains: `git checkout --ours` for conflicting files (keeps our loop/ branch changes) then `git add` and `git rebase --continue`
+- [ ] The guidance is explicit that "ours" means the worktree branch (loop/ branch), not the incoming remote changes
+- [ ] Alternative strategy (prefer remote) is documented but marked as not recommended for loop work
+
+**Implementation Detail:**
+```bash
+Conflict resolution guidance (add to step 4b and step 7):
+
+> **Conflict resolution strategy: prefer local (worktree) changes**
+>
+> When resolving rebase conflicts, prefer keeping your local changes (the worktree branch).
+> This is because the worktree branch contains the planned implementation, while the
+> remote branch is the shared baseline.
+>
+> For each conflicted file:
+> 1. Read the file to understand both sides of the conflict
+> 2. Edit the file to keep the version that preserves your intended implementation
+>    (typically the "ours" side — your loop/ branch changes)
+> 3. Stage the resolved file: `git add <file>`
+> 4. Continue the rebase: `git rebase --continue`
+>
+> If new conflicts appear, repeat until the rebase completes.
+>
+> **Why prefer local?** The looper worktree is a disposable context for implementing
+> a fix. The remote baseline is the source of truth. Preferring local ensures the
+> planned changes are preserved.
+>
+> **Alternative (not recommended):** To prefer remote changes instead, use
+> `git checkout --theirs <file>` before `git add`. This discards local changes
+> and is generally not what you want in a loop/ worktree.
+```
+
+---
+
+## Files to modify
+
+1. **`.opencode/skills/looper/SKILL.md`** — update step 4b, step 7, step 8, and add new steps 8a/8b/8c
+
+## Files to create
+
+1. **`.opencode/skills/looper/scripts/detect-migrations`** — optional shared migration detection script (can be inline in SKILL.md)
+
+---
+
+## Corner cases
+
+1. **CI never runs** — If no checks are configured, proceed directly to merge decision
+2. **CI fails** — Report failure, leave PR open, do NOT merge, exit with error
+3. **CI times out** — Report timeout, leave PR open, do NOT merge, exit with error
+4. **DB migrations detected** — Leave PR open, report manual merge required
+5. **No DB migrations + CI passes** — Squash-merge via create-github-pr
+6. **Step 7 rebase has conflicts** — Use prefer-local strategy, resolve and continue
+7. **Step 4b already rebased, no new commits** — Step 7 skips rebase entirely
+8. **Step 4b had conflicts but step 7 would skip** — Never skip if STATUS=conflicts from step 4b
+
+---
+
+## Testing approach
+
+Write tests for the new logic:
+
+1. **Test detect-migrations script** — various migration file patterns (true positive and true negative)
+2. **Test conditional re-sync** — when new commits exist vs when they don't
+3. **Test conflict resolution guidance** — verify the "prefer local" strategy is documented
+
+No TDD tests in SKILL.md since it's a specification document, not implementation code.


### PR DESCRIPTION
## Problem / Task

The looper skill delegated CI polling and DB-migration-aware merge strategy to the create-github-pr skill without making these phases visible in the PDC loop flow. Additionally, step 7 (sync before PR) was redundant if step 4b already succeeded, and conflict resolution had no prompting strategy.

**Current behavior:** Steps 8 and 9 delegate everything to create-github-pr; no explicit WAIT_FOR_CI phase; step 7 always re-syncs; no conflict resolution guidance.

**Expected behavior:** The looper skill should explicitly define WAIT_FOR_CI as a phase, include DB migration detection, skip re-sync in step 7 when unnecessary, and provide conflict resolution guidance.

## Existing Architecture

```mermaid
graph TD
    A[Step 6: PDC Loop] --> B[Step 7: Sync Before PR]
    B --> C[Step 8: Report & Create PR]
    C --> D[Step 9: Cleanup]
    D --> E[create-github-pr skill handles CI + merge]
    style E fill:#f66,stroke:#333
```

## Proposed Architecture

```mermaid
graph TD
    A[Step 6: PDC Loop] --> B[Step 7: Sync Before PR - conditional]
    B --> C[Step 8: Report & Create PR]
    C --> D[Step 8a: Wait for CI]
    D --> E[Step 8b: Detect DB Migrations]
    E --> F[Step 8c: Merge or Leave Open]
    F --> G[No migrations: squash-merge + cleanup]
    F --> H[Migrations: leave PR open]
    style D fill:#6f6,stroke:#333
    style E fill:#6f6,stroke:#333
    style F fill:#6f6,stroke:#333
```

## Key Changes

1. **Step 4b now captures SYNC_STATE** — exports `SYNC_STATUS` and `SYNC_HEAD` after sync for conditional re-sync in step 7.

2. **Step 7 is now conditional** — only re-syncs if new commits exist since step 4b; never skips if STATUS=conflicts.

3. **Step 8a (WAIT_FOR_CI)** — new explicit phase that polls CI with `gh pr checks --watch`, fails if CI fails/times out.

4. **Step 8b (DB migration detection)** — detects migration patterns (migrations/, db/migrate, alembic/versions, prisma/migrations, etc.) in the changeset.

5. **Step 8c (merge or leave open)** — leaves PR open if migrations detected; proceeds to create-github-pr for squash-merge otherwise.

6. **Step 4b conflict resolution guidance** — documents "prefer local changes" strategy using `git checkout --ours`, explaining that "ours" = loop/ branch.

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ✅ | 17 test cases in test-skill-changes.sh, all passing |
| Skill flow validation | ✅ | SKILL.md changes validated against acceptance criteria |