### PR TITLE
fix: add --prune to git fetch to remove stale remote-tracking branches

### DIFF
--- a/.opencode/scripts/sync-with-remote
+++ b/.opencode/scripts/sync-with-remote
@@ -25,7 +25,7 @@ if [ -n "$_GIT_DIR" ]; then
 fi
 
 # Fetch latest from origin
-if ! git fetch origin 1>&2; then
+if ! git fetch --prune origin 1>&2; then
     echo "[sync] ERROR: git fetch origin failed" >&2
     exit 2
 fi


### PR DESCRIPTION
## Problem / Task

This PR adds the `--prune` flag to the `git fetch origin` command in the `sync-with-remote` script, addressing issue #20.

**Current behavior:** `git fetch origin` only fetches new changes but leaves stale remote-tracking branches behind when branches are deleted on the remote.

**Expected behavior:** `git fetch --prune origin` fetches new changes and removes any remote-tracking branches that no longer exist on the remote, keeping the local repository clean.

## Existing Architecture

The `sync-with-remote` script performs a fetch and rebase onto the default remote branch. Previously, the fetch did not clean up stale remote-tracking references.

```mermaid
graph LR
    A[sync-with-remote script] --> B[git fetch origin]
    B --> C{Success?}
    C -->|Yes| D[Detect default branch]
    C -->|No| E[Exit with error]
    D --> F[Compute merge-base]
    F --> G{Rebase needed?}
    G -->|No| H[Exit up-to-date]
    G -->|Yes| I[git rebase origin/default]
```

## Proposed Architecture

The fetch now includes `--prune` to clean up stale remote-tracking branches in a single operation.

```mermaid
graph LR
    A[sync-with-remote script] --> B[git fetch --prune origin]
    B --> C{Success?}
    C -->|Yes| D[Detect default branch]
    C -->|No| E[Exit with error]
    D --> F[Compute merge-base]
    F --> G{Rebase needed?}
    G -->|No| H[Exit up-to-date]
    G -->|Yes| I[git rebase origin/default]
    
    style B fill:#6f6
    style D fill:#ff6
    style F fill:#ff6
    style G fill:#ff6
    style I fill:#ff6
```

## Key Changes

- **Line 28:** Changed `git fetch origin` → `git fetch --prune origin`
  - This removes stale remote-tracking branches during the fetch operation
  - No trade-offs: `--prune` is a safe, commonly-used flag that only removes refs that no longer exist on the remote

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests | ⏭️ | No unit tests for this script |
| Lint | ⏭️ | ShellCheck not configured |
| Type Check | ⏭️ | Not applicable (bash script) |
| Build | ⏭️ | Not applicable |