### PR TITLE
feat: add looper-bug-reporter agent

### DIFF
--- a/.opencode/agents/looper-bug-reporter.md
+++ b/.opencode/agents/looper-bug-reporter.md
@@ -1,0 +1,159 @@
+---
+name: looper-bug-reporter
+description: Detects and reports bugs found in the looper codebase (code-salad/open-looper) during PDC loop operations. Fire-and-forget — files issues without blocking the caller.
+mode: subagent
+tools:
+  read: true
+  glob: true
+  grep: true
+  bash: true
+  task: true
+---
+
+# Looper Bug Reporter Agent
+
+You are a specialized bug reporter for the looper project itself. When other agents
+in the PDC loop discover bugs, regressions, or unexpected behavior in the looper
+codebase, they invoke you to file structured bug reports in the upstream repo.
+
+## Your Mission
+
+When invoked with a looper-related bug description, create a well-structured GitHub
+issue in the `code-salad/open-looper` repository. Use the canonical bug format with
+`## Steps to Reproduce`, `## Expected Behavior`, and `## Actual Behavior` sections.
+
+## Instructions
+
+### 1. Determine the bug context from your prompt
+
+You will receive:
+- Description of the bug (what went wrong)
+- Where it was found (which agent, which phase, which task)
+- File paths and code references if available
+- Observed vs expected behavior
+- Any error messages or stack traces
+
+### 2. Set the target repository
+
+```bash
+export GH_REPO="code-salad/open-looper"
+```
+
+### 3. Check for duplicate bugs
+
+Before creating, search for similar open issues:
+```bash
+gh issue list --repo "$GH_REPO" --state open --search "<2-3 key terms from bug>" --limit 3
+```
+
+If a clearly matching issue already exists, stop. Report back:
+"Skipped — duplicate of #N: <title>"
+
+### 4. Check available labels in the target repo
+
+```bash
+gh label list --repo "$GH_REPO" --limit 30
+```
+
+Common labels for looper bugs:
+- "bug" — for all bug reports
+- "pdc" — if bug is in PDC loop logic
+- "agent" — if bug is in agent behavior
+- "cli" — if bug is in command-line interface
+- "blocked" — if issue has unresolved blockers (only if label exists)
+
+### 5. Gather additional context
+
+Read the relevant source files to understand the bug better:
+- Maximum 3 files for context
+- Look for related tests that might illustrate expected behavior
+- Check git history for recent changes to the affected area
+
+### 6. Create the bug report
+
+Use this canonical bug body structure:
+
+```markdown
+## Description
+<2-4 sentences describing the bug>
+
+## Steps to Reproduce
+1. <step 1>
+2. <step 2>
+3. <step 3>
+
+## Expected Behavior
+<what should happen>
+
+## Actual Behavior
+<what actually happens>
+
+## Environment
+- **Looper version:** (if determinable)
+- **Agent:** <which agent found this>
+- **Phase:** <planner/doer/checker/other>
+- **Task:** <brief description of the task that triggered this>
+
+## References
+- `path/to/file` — <why it's relevant>
+
+## Context
+- **Found by:** <agent name> during <phase> phase
+- **Triggered by task:** <task description>
+
+---
+🤖 Auto-filed by looper bug-reporter
+```
+
+### 7. Title format
+
+Use `bug: <concise description, max 70 chars>` as the title prefix.
+
+### 8. Create the issue
+
+```bash
+gh issue create \
+  --repo "$GH_REPO" \
+  --title "bug: <concise description max 70 chars>" \
+  --body "$(cat <<'EOF'
+<bug body following the canonical structure above>
+EOF
+)"
+```
+
+Add `--label "bug"` and any other relevant labels.
+
+### 9. Report back
+
+After creating, report:
+- Issue number and URL
+- Brief summary of what was filed
+- "Skipped — duplicate of #N" if applicable
+
+## Rules
+
+- **Fire-and-forget**: Do not block the calling agent
+- **Maximum 3 files** for context gathering
+- **Do NOT run tests** or start servers
+- **Do NOT over-investigate** — file quickly with what you have
+- If `gh` fails, report the error and stop
+- If duplicate exists, skip silently
+- The `## Dependencies`, `## Blockers`, and `## Subtasks` markers are
+  load-bearing in the looper-gh-issue-creator format, but for this agent
+  you only need the canonical bug sections
+- Always set `GH_REPO=code-salad/open-looper` explicitly
+
+## Integration with PDC Loop
+
+This agent is typically invoked by:
+- `looper-checker.md` — when adversarial testing finds a bug
+- `looper-check-build.md` — when typecheck/build fails in unexpected ways
+- `looper-check-runtime.md` — when runtime behavior is incorrect
+- `looper-debugger.md` — when root cause is a looper bug (not user code)
+
+When spawning, pass:
+- Bug description
+- File paths with line numbers
+- Error output if any
+- Which agent/phase found it
+- Task context that triggered it

--- a/docs/diagrams/01-context.md
+++ b/docs/diagrams/01-context.md
@@ -1,0 +1,60 @@
+# Context Diagram (L1)
+
+## open-looper System Context
+
+```mermaid
+C4Context
+    title Context Diagram - open-looper System
+
+    Enterprise_Boundary(enterprise, "open-looper Platform") {
+        Person(user, "User", "Initiates PDC loop tasks via OpenCode")
+        Container(opencode, "OpenCode", "AI coding assistant platform")
+        Container(agents, "Agents", "PDC loop agents (planner, doer, checker, subagents)")
+        Container(scripts, "Scripts", "Helper scripts for git, docker, etc.")
+        Container(worktrees, "Worktrees", "Git worktree isolation layer")
+    }
+
+    System_Ext(github, "GitHub", "Hosts repository, CI/CD, Pull Requests")
+    System_Ext(docker, "Docker", "Container runtime for integration tests")
+    System_Ext(git, "Git", "Version control with worktree support")
+    System_Ext(opencode_ext, "OpenCode API", "External OpenCode platform API")
+
+    Rel(user, opencode, "Issues /looper commands")
+    Rel(opencode, agents, "Spawns PDC agents")
+    Rel(agents, scripts, "Uses helper scripts")
+    Rel(agents, worktrees, "Createsisolated worktrees per task")
+    Rel(agents, github, "Creates commits, PRs via gh CLI")
+    Rel(scripts, docker, "Runs integration tests")
+    Rel(worktrees, git, "Manages git repository state")
+    Rel(github, opencode_ext, "Webhook notifications")
+    Rel(docker, github, "Builds and pushes images")
+
+    UpdateRelStyle(user, opencode, $offsetX="0", $offsetY="-40")
+    UpdateRelStyle(opencode, agents, $offsetX="0", $offsetY="40")
+    UpdateRelStyle(agents, github, $offsetX="40", $offsetY="0")
+    UpdateRelStyle(github, docker, $offsetX="40", $offsetY="20")
+```
+
+## Legend
+
+| Element | Description |
+|---------|-------------|
+| **Person** | Human actors (User) |
+| **Container** | Applications or data stores within the system |
+| **System_Ext** | External systems outside the open-looper boundary |
+| **Enterprise_Boundary** | Groups elements belonging to the same platform |
+
+## External Dependencies
+
+- **GitHub**: Repository hosting, CI/CD pipelines, PR creation via `gh` CLI
+- **Docker**: Integration test execution, container builds
+- **Git**: Worktree management, commit history
+- **OpenCode API**: External platform for webhook events
+
+## Key Interactions
+
+1. User issues a `/looper <task>` command via OpenCode
+2. OpenCode spawns the Planner → Doer → Checker cycle
+3. Agents create git worktrees for isolated development
+4. Helper scripts manage Docker containers for integration tests
+5. Commits and PRs are pushed to GitHub via `gh` CLI

--- a/docs/diagrams/01-context.md
+++ b/docs/diagrams/01-context.md
@@ -1,60 +1,44 @@
-# Context Diagram (L1)
-
-## open-looper System Context
+# L1 Context Diagram - Open-Looper System Overview
 
 ```mermaid
 C4Context
-    title Context Diagram - open-looper System
+  title Open-Looper System Context
 
-    Enterprise_Boundary(enterprise, "open-looper Platform") {
-        Person(user, "User", "Initiates PDC loop tasks via OpenCode")
-        Container(opencode, "OpenCode", "AI coding assistant platform")
-        Container(agents, "Agents", "PDC loop agents (planner, doer, checker, subagents)")
-        Container(scripts, "Scripts", "Helper scripts for git, docker, etc.")
-        Container(worktrees, "Worktrees", "Git worktree isolation layer")
-    }
+  Person(user, "User", "Human developer who initiates development tasks and reviews results")
 
-    System_Ext(github, "GitHub", "Hosts repository, CI/CD, Pull Requests")
-    System_Ext(docker, "Docker", "Container runtime for integration tests")
-    System_Ext(git, "Git", "Version control with worktree support")
-    System_Ext(opencode_ext, "OpenCode API", "External OpenCode platform API")
+  System_Ext(github, "GitHub", "GitHub platform for repository hosting, issues, and pull requests")
+  System_Ext(docker, "Docker", "Container runtime for isolated execution environments")
+  System_Ext(opencode, "OpenCode", "Plugin host that loads and executes the looper plugin")
 
-    Rel(user, opencode, "Issues /looper commands")
-    Rel(opencode, agents, "Spawns PDC agents")
-    Rel(agents, scripts, "Uses helper scripts")
-    Rel(agents, worktrees, "Createsisolated worktrees per task")
-    Rel(agents, github, "Creates commits, PRs via gh CLI")
-    Rel(scripts, docker, "Runs integration tests")
-    Rel(worktrees, git, "Manages git repository state")
-    Rel(github, opencode_ext, "Webhook notifications")
-    Rel(docker, github, "Builds and pushes images")
+  System(looper, "Open-Looper", "AI-powered Plan-Do-Check loop orchestration system")
+  System_Ext(scripts, "Scripts", ".opencode/scripts - Bash scripts for automation and integration")
+  System_Ext(worktrees, "Worktrees", ".worktrees/ - Isolated git worktrees for parallel development")
 
-    UpdateRelStyle(user, opencode, $offsetX="0", $offsetY="-40")
-    UpdateRelStyle(opencode, agents, $offsetX="0", $offsetY="40")
-    UpdateRelStyle(agents, github, $offsetX="40", $offsetY="0")
-    UpdateRelStyle(github, docker, $offsetX="40", $offsetY="20")
+  Rel(user, github, "Creates issues, reviews PRs", "gh CLI")
+  Rel(user, opencode, "Invokes via plugin API", "OpenCode plugin interface")
+
+  Rel(looper, github, "Reads/writes issues, creates PRs", "GitHub API")
+  Rel(looper, docker, "Spawns containers for execution", "Docker API")
+  Rel(looper, opencode, "Runs as plugin within host", "Plugin protocol")
+  Rel(looper, scripts, "Executes via bash", "Shell commands")
+  Rel(looper, worktrees, "Creates and manages worktrees", "Git worktree commands")
+
+  Rel(scripts, github, "CI/CD integration", "gh/webhooks")
+  Rel(scripts, docker, "Container management", "docker CLI")
+  Rel(worktrees, github, "Linked to remotes", "git push/fetch")
+
+  ShowLegend()
 ```
 
-## Legend
+## Description
 
-| Element | Description |
-|---------|-------------|
-| **Person** | Human actors (User) |
-| **Container** | Applications or data stores within the system |
-| **System_Ext** | External systems outside the open-looper boundary |
-| **Enterprise_Boundary** | Groups elements belonging to the same platform |
+The context diagram shows the open-looper system as the central component, with four external actors:
 
-## External Dependencies
+| Actor | Role |
+|-------|------|
+| **User** | Human developer who initiates tasks, reviews AI-generated code, and approves changes |
+| **GitHub** | Repository platform providing issue tracking, PR capabilities, and CI/CD hooks |
+| **Docker** | Container runtime providing isolated execution environments for agent operations |
+| **OpenCode** | Plugin host that loads and executes the looper as a plugin within its context |
 
-- **GitHub**: Repository hosting, CI/CD pipelines, PR creation via `gh` CLI
-- **Docker**: Integration test execution, container builds
-- **Git**: Worktree management, commit history
-- **OpenCode API**: External platform for webhook events
-
-## Key Interactions
-
-1. User issues a `/looper <task>` command via OpenCode
-2. OpenCode spawns the Planner → Doer → Checker cycle
-3. Agents create git worktrees for isolated development
-4. Helper scripts manage Docker containers for integration tests
-5. Commits and PRs are pushed to GitHub via `gh` CLI
+The system interacts with all four actors to orchestrate the Plan-Do-Check development loop.

--- a/docs/diagrams/02-container.md
+++ b/docs/diagrams/02-container.md
@@ -1,0 +1,84 @@
+# Container Diagram (L2)
+
+## open-looper Container Architecture
+
+```mermaid
+C4Container
+    title Container Diagram - open-looper PDC Loop
+
+    Person(user, "User", "Issues /looper commands via OpenCode")
+
+    Container_Boundary(opencode_plugin, "OpenCode Plugin") {
+        Container(opencode_core, "OpenCode Core", "AI coding assistant core")
+        Container(skill_looper, "looper Skill", "Orchestrates PDC loop via Task tool")
+    }
+
+    Container_Boundary(agents, "Agents Container") {
+        Container(planner, "Planner Agent", "Creates actionable plans from tasks")
+        Container(doer, "Doer Agent", "Implements via TDD (red-green cycle)")
+        Container(checker, "Checker Agent", "Reviews and issues PASS/FAIL verdict")
+        Container(subagents, "Subagents", "debugger, simplifier, check-*, plan-*")
+    }
+
+    Container_Boundary(scripts, "Scripts Container") {
+        Container(git_scripts, "Git Scripts", "git-commit-loop, setup-worktree, git-loop-context")
+        Container(docker_scripts, "Docker Scripts", "compose-lifecycle, run-integration-tests")
+        Container(stack_scripts, "Stack Scripts", "detect-stack, run-tests, run-lint, run-typecheck")
+        Container(check_scripts, "Check Scripts", "check-scope, detect-resume, resolve-plan-pointers")
+    }
+
+    Container_Boundary(worktrees, "Worktrees Container") {
+        Container(worktree_manager, "Worktree Manager", "Creates/removes isolated git worktrees")
+        Container(task_worktrees, "Task Worktrees", ".worktrees/<task>/ per iteration")
+    }
+
+    System_Ext(github, "GitHub", "Repository, CI/CD, Pull Requests")
+    System_Ext(docker, "Docker", "Integration test runtime")
+    System_Ext(git, "Git", "Version control with worktree support")
+
+    Rel(user, opencode_core, "/looper <task>")
+    Rel(opencode_core, skill_looper, "Triggers looper skill")
+    Rel(skill_looper, planner, "Spawns planner agent")
+    Rel(skill_looper, doer, "Spawns doer agent")
+    Rel(skill_looper, checker, "Spawns checker agent")
+    Rel(planner, subagents, "Spawns for parallel analysis")
+    Rel(doer, subagents, "Spawns simplifier, debugger")
+    Rel(checker, subagents, "Spawns check-* subagents")
+    Rel(subagents, scripts, "Uses helper scripts")
+    Rel(scripts, worktree_manager, "Manages worktrees")
+    Rel(worktree_manager, task_worktrees, "Creates isolated development")
+    Rel(scripts, github, "gh CLI for commits/PRs")
+    Rel(docker_scripts, docker, "Runs containers")
+    Rel(task_worktrees, git, "Git operations")
+```
+
+## Legend
+
+| Container Type | Description |
+|----------------|-------------|
+| **OpenCode Plugin** | The OpenCode platform with looper skill |
+| **Agents Container** | PDC loop agents (planner, doer, checker + subagents) |
+| **Scripts Container** | Helper scripts for git, docker, stack detection |
+| **Worktrees Container** | Git worktree isolation per task |
+
+## Technology Stack
+
+| Component | Technology |
+|-----------|------------|
+| Agent Definitions | Markdown (`.md` files) |
+| Scripting | Bash, Node.js |
+| Version Control | Git with worktrees |
+| Container Runtime | Docker, docker-compose |
+| Communication | Task tool (OpenCode) |
+
+## Container Responsibilities
+
+| Container | Responsibility |
+|-----------|----------------|
+| **Planner Agent** | Explores codebase, produces actionable plan |
+| **Doer Agent** | TDD red-green cycle, commits implementation |
+| **Checker Agent** | Reviews code, issues PASS/FAIL verdict |
+| **Subagents** | Specialized tasks (debug, simplify, check-*) |
+| **Git Scripts** | Worktree setup, conventional commits |
+| **Docker Scripts** | Integration test execution |
+| **Worktrees** | Isolated development per task/iteration |

--- a/docs/diagrams/02-container.md
+++ b/docs/diagrams/02-container.md
@@ -1,84 +1,49 @@
-# Container Diagram (L2)
-
-## open-looper Container Architecture
+# L2 Container Diagram - Open-Looper Architecture
 
 ```mermaid
 C4Container
-    title Container Diagram - open-looper PDC Loop
+  title Open-Looper Container Diagram
 
-    Person(user, "User", "Issues /looper commands via OpenCode")
+  Person(user, "User", "Human developer")
 
-    Container_Boundary(opencode_plugin, "OpenCode Plugin") {
-        Container(opencode_core, "OpenCode Core", "AI coding assistant core")
-        Container(skill_looper, "looper Skill", "Orchestrates PDC loop via Task tool")
-    }
+  Boundary(looper, "Open-Looper") {
+    Container(agents, "Agents", "Node.js/TypeScript", "Orchestrates PDC loop: looper-planner, looper-doer, looper-checker")
+    Container(scripts, "Scripts", "Bash/sh", ".opencode/scripts/*.sh - Automation utilities")
+    Container(plugin, "Plugin", "TypeScript", "OpenCode plugin framework integration")
+    Container(worktrees, "Worktrees", "Git", ".worktrees/ - Isolated development branches")
+  }
 
-    Container_Boundary(agents, "Agents Container") {
-        Container(planner, "Planner Agent", "Creates actionable plans from tasks")
-        Container(doer, "Doer Agent", "Implements via TDD (red-green cycle)")
-        Container(checker, "Checker Agent", "Reviews and issues PASS/FAIL verdict")
-        Container(subagents, "Subagents", "debugger, simplifier, check-*, plan-*")
-    }
+  System_Ext(github, "GitHub", "Issue tracking and PRs via gh CLI")
+  System_Ext(docker, "Docker", "Container runtime for isolation")
+  System_Ext(opencode, "OpenCode", "Plugin host environment")
 
-    Container_Boundary(scripts, "Scripts Container") {
-        Container(git_scripts, "Git Scripts", "git-commit-loop, setup-worktree, git-loop-context")
-        Container(docker_scripts, "Docker Scripts", "compose-lifecycle, run-integration-tests")
-        Container(stack_scripts, "Stack Scripts", "detect-stack, run-tests, run-lint, run-typecheck")
-        Container(check_scripts, "Check Scripts", "check-scope, detect-resume, resolve-plan-pointers")
-    }
+  Rel(user, plugin, "Invokes via OpenCode", "Plugin API")
+  Rel(plugin, agents, "Delegates to agents", "Direct function call")
+  Rel(agents, scripts, "Executes scripts", "Bash subprocess")
+  Rel(agents, worktrees, "Manages worktrees", "Git commands")
+  Rel(agents, github, "API calls via gh", "REST API")
+  Rel(scripts, docker, "Container ops", "docker CLI")
+  Rel(worktrees, github, "Remote sync", "git push/fetch")
 
-    Container_Boundary(worktrees, "Worktrees Container") {
-        Container(worktree_manager, "Worktree Manager", "Creates/removes isolated git worktrees")
-        Container(task_worktrees, "Task Worktrees", ".worktrees/<task>/ per iteration")
-    }
+  Rel_D(agents, plugin, "Reports status", "Event emitter")
 
-    System_Ext(github, "GitHub", "Repository, CI/CD, Pull Requests")
-    System_Ext(docker, "Docker", "Integration test runtime")
-    System_Ext(git, "Git", "Version control with worktree support")
-
-    Rel(user, opencode_core, "/looper <task>")
-    Rel(opencode_core, skill_looper, "Triggers looper skill")
-    Rel(skill_looper, planner, "Spawns planner agent")
-    Rel(skill_looper, doer, "Spawns doer agent")
-    Rel(skill_looper, checker, "Spawns checker agent")
-    Rel(planner, subagents, "Spawns for parallel analysis")
-    Rel(doer, subagents, "Spawns simplifier, debugger")
-    Rel(checker, subagents, "Spawns check-* subagents")
-    Rel(subagents, scripts, "Uses helper scripts")
-    Rel(scripts, worktree_manager, "Manages worktrees")
-    Rel(worktree_manager, task_worktrees, "Creates isolated development")
-    Rel(scripts, github, "gh CLI for commits/PRs")
-    Rel(docker_scripts, docker, "Runs containers")
-    Rel(task_worktrees, git, "Git operations")
+  ShowLegend()
 ```
-
-## Legend
-
-| Container Type | Description |
-|----------------|-------------|
-| **OpenCode Plugin** | The OpenCode platform with looper skill |
-| **Agents Container** | PDC loop agents (planner, doer, checker + subagents) |
-| **Scripts Container** | Helper scripts for git, docker, stack detection |
-| **Worktrees Container** | Git worktree isolation per task |
-
-## Technology Stack
-
-| Component | Technology |
-|-----------|------------|
-| Agent Definitions | Markdown (`.md` files) |
-| Scripting | Bash, Node.js |
-| Version Control | Git with worktrees |
-| Container Runtime | Docker, docker-compose |
-| Communication | Task tool (OpenCode) |
 
 ## Container Responsibilities
 
-| Container | Responsibility |
-|-----------|----------------|
-| **Planner Agent** | Explores codebase, produces actionable plan |
-| **Doer Agent** | TDD red-green cycle, commits implementation |
-| **Checker Agent** | Reviews code, issues PASS/FAIL verdict |
-| **Subagents** | Specialized tasks (debug, simplify, check-*) |
-| **Git Scripts** | Worktree setup, conventional commits |
-| **Docker Scripts** | Integration test execution |
-| **Worktrees** | Isolated development per task/iteration |
+| Container | Technology | Purpose |
+|-----------|------------|---------|
+| **Agents** | Node.js/TypeScript | Core PDC orchestration - Planner creates plans, Doer implements, Checker verifies |
+| **Scripts** | Bash/sh | Automation utilities for git operations, docker management, file manipulation |
+| **Plugin** | TypeScript | Integrates looper into OpenCode as a plugin, exposes CLI commands |
+| **Worktrees** | Git | Creates isolated development branches in `.worktrees/` for parallel experiments |
+
+## Key Interactions
+
+1. User invokes the plugin via OpenCode
+2. Plugin delegates to the Agents container
+3. Agents orchestrate the loop using Scripts for automation
+4. Worktrees provide isolated development environments
+5. GitHub integration handles version control and collaboration
+6. Docker provides runtime isolation for agent execution

--- a/docs/diagrams/03-component.md
+++ b/docs/diagrams/03-component.md
@@ -1,96 +1,65 @@
-# Component Diagram (L3)
-
-## open-looper Component Architecture
+# L3 Component Diagram - Agent Internals
 
 ```mermaid
 C4Component
-    title Component Diagram - Agent and Script Internals
+  title Open-Looper Component Diagram - Agents & Scripts
 
-    Component_Boundary(planner_boundary, "Planner Agent") {
-        Component(planner_explore, "Explorer", "Spawns Explore subagents to read files")
-        Component(planner_plan_writer, "Plan Writer", "Writes plan to .opencode/plans/")
-        Component(planner_committer, "Git Committer", "Commits plan via git-commit-loop")
-    }
+  Container_Boundary(agents, "Agents Container") {
+    Component(planner, "Planner Agent", "TypeScript", "Creates implementation plans from task descriptions")
+    Component(doer, "Doer Agent", "TypeScript", "Implements plans using TDD red-green cycle")
+    Component(checker, "Checker Agent", "TypeScript", "Verifies implementation against acceptance criteria")
+    Component(subagents, "Sub-Agents", "TypeScript", "looper-debugger, looper-simplifier, gh-issue-creator, etc.")
 
-    Component_Boundary(doer_boundary, "Doer Agent") {
-        Component(doer_red, "RED Phase", "Writes failing tests first (TDD)")
-        Component(doer_green, "GREEN Phase", "Implements minimal code to pass tests")
-        Component(doer_simplify, "SIMPLIFY Phase", "Refines implementation via simplifier subagent")
-        Component(doer_integration, "INTEGRATION Phase", "Writes integration tests if applicable")
-    }
+    Component(scripts_lib, "Scripts Library", "Bash", "git-commit-loop, run-tests, run-lint, detect-stack, etc.")
+    Component(state, "State Manager", "TypeScript", "Manages loop iteration state and commit history")
+  }
 
-    Component_Boundary(checker_boundary, "Checker Agent") {
-        Component(checker_review, "Reviewer", "Spawns check-* subagents for reviews")
-        Component(checker_verdict, "Verdict Issuer", "Issues PASS/FAIL based on subagent reports")
-        Component(checker_pr, "PR Creator", "Creates GitHub PR on PASS verdict")
-    }
+  Container_Boundary(scripts, "Scripts Container") {
+    Component(git_ops, "Git Operations", "Bash", "git-commit-loop, git-loop-context, check-scope")
+    Component(testing, "Testing Utils", "Bash", "run-tests, run-integration-tests, install-deps")
+    Component(detection, "Detection Utils", "Bash", "detect-stack, detect-compose, resolve-plan-pointers")
+    Component(lifecycle, "Lifecycle Scripts", "Bash", "compose-lifecycle, scaffold-integration-ci")
+  }
 
-    Component_Boundary(scripts_boundary, "Script Libraries") {
-        Component(git_commit_loop, "git-commit-loop", "Creates conventional commits with loop trailers")
-        Component(setup_worktree, "setup-worktree", "Creates isolated git worktree per task")
-        Component(git_loop_context, "git-loop-context", "Reads prior loop iterations from git log")
-        Component(run_tests, "run-tests", "Executes project test suite")
-        Component(run_lint, "run-lint", "Runs linter with auto-fix")
-        Component(run_typecheck, "run-typecheck", "Runs type checker")
-        Component(compose_lifecycle, "compose-lifecycle", "Manages docker-compose services")
-        Component(detect_stack, "detect-stack", "Detects project tech stack")
-        Component(check_scope, "check-scope", "Detects scope drift in commits")
-    }
+  Rel(planner, state, "Reads/writes iteration state")
+  Rel(doer, state, "Reads/writes iteration state")
+  Rel(checker, state, "Reads iteration state for verification")
 
-    Rel(planner_explore, planner_plan_writer, "Produces exploration results")
-    Rel(planner_plan_writer, planner_committer, "Commits plan")
-    Rel(doer_red, doer_green, "Tests fail → implement")
-    Rel(doer_green, doer_simplify, "Tests pass → refine")
-    Rel(doer_simplify, doer_integration, "Simplify complete → integration")
-    Rel(checker_review, checker_verdict, "Reviews complete → verdict")
-    Rel(checker_verdict, checker_pr, "PASS verdict → create PR")
-    Rel(doer_green, git_commit_loop, "Commits with trailers")
-    Rel(doer_green, setup_worktree, "Creates worktrees")
-    Rel(doer_green, run_tests, "Runs tests")
-    Rel(doer_green, run_lint, "Runs linter")
-    Rel(doer_green, run_typecheck, "Runs typecheck")
-    Rel(doer_integration, compose_lifecycle, "Manages docker services")
-    Rel(checker_review, detect_stack, "Detects tech stack")
-    Rel(checker_review, check_scope, "Checks scope compliance")
+  Rel(doer, scripts_lib, "Calls scripts for execution")
+  Rel(subagents, scripts_lib, "Calls scripts for execution")
+
+  Rel(scripts_lib, git_ops, "Implements git operations")
+  Rel(scripts_lib, testing, "Implements testing utilities")
+  Rel(scripts_lib, detection, "Implements detection utilities")
+  Rel(scripts_lib, lifecycle, "Implements lifecycle management")
+
+  Rel(subagents, planner, "Spawned by planner for exploration")
+  Rel(subagents, doer, "Spawned by doer for debugging")
+  Rel(subagents, checker, "Spawned by checker for adversarial testing")
+
+  ShowLegend()
 ```
 
-## Legend
+## Component Details
 
-| Component Type | Description |
-|----------------|-------------|
-| **Planner Agent** | Phase 1: Exploration, planning, plan commit |
-| **Doer Agent** | Phase 2: TDD red-green-simplify cycle |
-| **Checker Agent** | Phase 3: Review, verdict, PR creation |
-| **Script Libraries** | Reusable helper scripts |
+### Core Agents
+| Component | Responsibility |
+|-----------|----------------|
+| **Planner** | Analyzes task, explores codebase, creates implementation plans with test descriptions |
+| **Doer** | Follows TDD cycle - writes failing tests (RED), implements to pass (GREEN), refactors (SIMPLIFY) |
+| **Checker** | Reviews doer's work, runs verification, issues PASS/FAIL verdict |
+| **Sub-Agents** | Specialized agents for debugging, simplification, issue creation, adversarial review |
 
-## Agent State Machine
+### Script Libraries
+| Component | Purpose |
+|-----------|---------|
+| **Git Operations** | Commit management, scope checking, plan pointer resolution |
+| **Testing Utils** | Test execution, dependency installation, integration test runner |
+| **Detection Utils** | Stack detection, docker-compose detection, plan resolution |
+| **Lifecycle Scripts** | Docker compose management, CI scaffolding |
 
-### Planner Agent States
-1. **EXPLORE** → Spawns Explore subagents for parallel analysis
-2. **PLAN** → Writes actionable plan to filesystem
-3. **COMMIT** → Commits plan via git-commit-loop with phase trailers
-
-### Doer Agent States
-1. **RED** → Writes failing tests, commits test-only changes
-2. **GREEN** → Implements minimal code, commits implementation
-3. **SIMPLIFY** → Refines code via simplifier subagent
-4. **INTEGRATION** → Writes integration tests (if applicable)
-
-### Checker Agent States
-1. **REVIEW** → Spawns check-* subagents in parallel
-2. **VERDICT** → Aggregates reviews, issues PASS/FAIL
-3. **PR** → On PASS: creates GitHub PR via gh CLI
-
-## Script Library Details
-
-| Script | Purpose | Key Functions |
-|--------|---------|---------------|
-| `git-commit-loop` | Conventional commits | Adds Loop-Phase, Loop-Iteration trailers |
-| `setup-worktree` | Worktree creation | Creates .worktrees/<task>/ isolated branch |
-| `git-loop-context` | Git history analysis | Extracts prior iterations from commit messages |
-| `run-tests` | Test execution | Runs project-specific test command |
-| `run-lint` | Linting | Runs linter, supports --fix |
-| `run-typecheck` | Type checking | Runs type checker for the language |
-| `compose-lifecycle` | Docker management | up/down/status for backing services |
-| `detect-stack` | Stack detection | Detects Node.js, Python, Rust, etc. |
-| `check-scope` | Scope compliance | Detects drift from planned files |
+### State Management
+The state manager maintains iteration context across the PDC loop, tracking:
+- Current iteration number
+- Plan/RED/GREEN/SIMPLIFY/INTEGRATION commit hashes
+- Verdict history and checker feedback

--- a/docs/diagrams/03-component.md
+++ b/docs/diagrams/03-component.md
@@ -1,0 +1,96 @@
+# Component Diagram (L3)
+
+## open-looper Component Architecture
+
+```mermaid
+C4Component
+    title Component Diagram - Agent and Script Internals
+
+    Component_Boundary(planner_boundary, "Planner Agent") {
+        Component(planner_explore, "Explorer", "Spawns Explore subagents to read files")
+        Component(planner_plan_writer, "Plan Writer", "Writes plan to .opencode/plans/")
+        Component(planner_committer, "Git Committer", "Commits plan via git-commit-loop")
+    }
+
+    Component_Boundary(doer_boundary, "Doer Agent") {
+        Component(doer_red, "RED Phase", "Writes failing tests first (TDD)")
+        Component(doer_green, "GREEN Phase", "Implements minimal code to pass tests")
+        Component(doer_simplify, "SIMPLIFY Phase", "Refines implementation via simplifier subagent")
+        Component(doer_integration, "INTEGRATION Phase", "Writes integration tests if applicable")
+    }
+
+    Component_Boundary(checker_boundary, "Checker Agent") {
+        Component(checker_review, "Reviewer", "Spawns check-* subagents for reviews")
+        Component(checker_verdict, "Verdict Issuer", "Issues PASS/FAIL based on subagent reports")
+        Component(checker_pr, "PR Creator", "Creates GitHub PR on PASS verdict")
+    }
+
+    Component_Boundary(scripts_boundary, "Script Libraries") {
+        Component(git_commit_loop, "git-commit-loop", "Creates conventional commits with loop trailers")
+        Component(setup_worktree, "setup-worktree", "Creates isolated git worktree per task")
+        Component(git_loop_context, "git-loop-context", "Reads prior loop iterations from git log")
+        Component(run_tests, "run-tests", "Executes project test suite")
+        Component(run_lint, "run-lint", "Runs linter with auto-fix")
+        Component(run_typecheck, "run-typecheck", "Runs type checker")
+        Component(compose_lifecycle, "compose-lifecycle", "Manages docker-compose services")
+        Component(detect_stack, "detect-stack", "Detects project tech stack")
+        Component(check_scope, "check-scope", "Detects scope drift in commits")
+    }
+
+    Rel(planner_explore, planner_plan_writer, "Produces exploration results")
+    Rel(planner_plan_writer, planner_committer, "Commits plan")
+    Rel(doer_red, doer_green, "Tests fail → implement")
+    Rel(doer_green, doer_simplify, "Tests pass → refine")
+    Rel(doer_simplify, doer_integration, "Simplify complete → integration")
+    Rel(checker_review, checker_verdict, "Reviews complete → verdict")
+    Rel(checker_verdict, checker_pr, "PASS verdict → create PR")
+    Rel(doer_green, git_commit_loop, "Commits with trailers")
+    Rel(doer_green, setup_worktree, "Creates worktrees")
+    Rel(doer_green, run_tests, "Runs tests")
+    Rel(doer_green, run_lint, "Runs linter")
+    Rel(doer_green, run_typecheck, "Runs typecheck")
+    Rel(doer_integration, compose_lifecycle, "Manages docker services")
+    Rel(checker_review, detect_stack, "Detects tech stack")
+    Rel(checker_review, check_scope, "Checks scope compliance")
+```
+
+## Legend
+
+| Component Type | Description |
+|----------------|-------------|
+| **Planner Agent** | Phase 1: Exploration, planning, plan commit |
+| **Doer Agent** | Phase 2: TDD red-green-simplify cycle |
+| **Checker Agent** | Phase 3: Review, verdict, PR creation |
+| **Script Libraries** | Reusable helper scripts |
+
+## Agent State Machine
+
+### Planner Agent States
+1. **EXPLORE** → Spawns Explore subagents for parallel analysis
+2. **PLAN** → Writes actionable plan to filesystem
+3. **COMMIT** → Commits plan via git-commit-loop with phase trailers
+
+### Doer Agent States
+1. **RED** → Writes failing tests, commits test-only changes
+2. **GREEN** → Implements minimal code, commits implementation
+3. **SIMPLIFY** → Refines code via simplifier subagent
+4. **INTEGRATION** → Writes integration tests (if applicable)
+
+### Checker Agent States
+1. **REVIEW** → Spawns check-* subagents in parallel
+2. **VERDICT** → Aggregates reviews, issues PASS/FAIL
+3. **PR** → On PASS: creates GitHub PR via gh CLI
+
+## Script Library Details
+
+| Script | Purpose | Key Functions |
+|--------|---------|---------------|
+| `git-commit-loop` | Conventional commits | Adds Loop-Phase, Loop-Iteration trailers |
+| `setup-worktree` | Worktree creation | Creates .worktrees/<task>/ isolated branch |
+| `git-loop-context` | Git history analysis | Extracts prior iterations from commit messages |
+| `run-tests` | Test execution | Runs project-specific test command |
+| `run-lint` | Linting | Runs linter, supports --fix |
+| `run-typecheck` | Type checking | Runs type checker for the language |
+| `compose-lifecycle` | Docker management | up/down/status for backing services |
+| `detect-stack` | Stack detection | Detects Node.js, Python, Rust, etc. |
+| `check-scope` | Scope compliance | Detects drift from planned files |

--- a/docs/diagrams/04-code.md
+++ b/docs/diagrams/04-code.md
@@ -1,0 +1,184 @@
+# Code Diagram (L4)
+
+## open-looper Key Implementation Patterns
+
+```mermaid
+C4Component
+    title Code Diagram - Key Patterns and Formats
+
+    Component_Boundary(patterns, "Implementation Patterns") {
+        Component(agent_def, "Agent Definition Format", "Markdown-based agent specifications")
+        Component(git_trailers, "Git Commit Trailers", "Loop-Phase, Loop-Iteration, Loop-Verdict")
+        Component(worktree_setup, "Worktree Setup", "Git worktree isolation per task")
+        Component(tdd_cycle, "TDD Cycle", "RED → GREEN → SIMPLIFY")
+    }
+
+    Component_Boundary(formats, "Data Formats") {
+        Component(plan_format, "Plan Format", ".opencode/plans/<task>/iteration-N.md")
+        Component(context_format, "Context Format", "JSON with TASK_NAME, ITERATION, SCRIPTS_DIR")
+        Component(commit_msg, "Commit Message", "type(scope): description body")
+    }
+
+    Rel(agent_def, git_trailers, "Uses for auditing")
+    Rel(agent_def, worktree_setup, "Creates isolation")
+    Rel(git_trailers, tdd_cycle, "Tracks phase progression")
+    Rel(plan_format, context_format, "Passes context to agents")
+    Rel(worktree_setup, commit_msg, "Creates conventional commits")
+    Rel(tdd_cycle, commit_msg, "Generates commit messages")
+```
+
+## Pattern 1: Agent Definition Format
+
+```markdown
+# Agent Name
+
+## Description
+Brief description of agent purpose.
+
+## Mode
+primary | subagent
+
+## Instructions
+Step-by-step instructions...
+
+## Usage
+```bash
+$AGENTS_DIR/<agent-name>
+```
+
+## Examples
+Example invocations...
+```
+
+## Pattern 2: Git Commit Trailers
+
+Commits follow conventional commit format with PDC loop trailers:
+
+```
+type(scope): short description
+
+Longer description of changes made.
+
+Loop-Phase: do-red | do-green | do-simplify | do-integration
+Loop-Iteration: N
+Loop-Verdict: PASS | FAIL (at checker phase)
+```
+
+### Trailer Types
+
+| Trailer | Values | Purpose |
+|---------|--------|---------|
+| **Loop-Phase** | plan, do-red, do-green, do-simplify, do-integration, do-check | Current phase |
+| **Loop-Iteration** | 1, 2, 3, ... | Iteration number |
+| **Loop-Verdict** | PASS, FAIL | Checker verdict (if applicable) |
+
+## Pattern 3: Worktree Setup
+
+```bash
+# Create isolated worktree for task
+setup-worktree --task <task-name> --iteration <N>
+
+# Result: .worktrees/<task-name>/
+# - Isolated git branch per task
+# - No interference with main branch
+# - Easy cleanup on completion
+```
+
+### Worktree Directory Structure
+
+```
+.worktrees/
+└── <task-name>/
+    ├── .git/              # Worktree git data
+    ├── .opencode/         # Agent definitions
+    │   └── agents/
+    ├── docs/              # Documentation
+    └── [project files]    # Task-specific changes
+```
+
+## Pattern 4: TDD Cycle (RED-GREEN-SIMPLIFY)
+
+```
+┌─────────────────────────────────────────┐
+│  RED PHASE                              │
+│  - Write failing test first             │
+│  - Commit: "red: add failing tests"     │
+│  - Loop-Phase: do-red                   │
+└────────────────┬──────────────────────┘
+                 │ Tests fail
+                 ▼
+┌─────────────────────────────────────────┐
+│  GREEN PHASE                            │
+│  - Implement minimal code to pass       │
+│  - Commit: "green: implement feature"   │
+│  - Loop-Phase: do-green                 │
+└────────────────┬──────────────────────┘
+                 │ Tests pass
+                 ▼
+┌─────────────────────────────────────────┐
+│  SIMPLIFY PHASE                         │
+│  - Refine implementation                 │
+│  - Remove redundancy, improve naming    │
+│  - Commit: "simplify: refine impl"      │
+│  - Loop-Phase: do-simplify               │
+└─────────────────────────────────────────┘
+```
+
+## Pattern 5: Plan Format
+
+```markdown
+# Plan: <Task Name>
+
+## Bug Analysis / Feature Description
+...
+
+## Fix Plan / Implementation Plan
+...
+
+## Files to modify
+...
+
+## Tests
+...
+
+## Acceptance Criteria
+...
+
+Loop-Phase: plan
+Loop-Iteration: N
+```
+
+## Pattern 6: Agent Context (JSON)
+
+```json
+{
+  "TASK_NAME": "add-authentication",
+  "ITERATION": 1,
+  "MAX_ITERATIONS": 5,
+  "SCRIPTS_DIR": "/path/to/.opencode/scripts",
+  "AGENTS_DIR": "/path/to/.opencode/agents",
+  "WORKTREE_DIR": "/path/to/.worktrees/add-authentication"
+}
+```
+
+## Pattern 7: Conventional Commit Format
+
+```
+<type>(<scope>): <short description>
+
+[optional body]
+
+[optional trailers]
+```
+
+### Commit Types
+
+| Type | Description |
+|------|-------------|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `refactor` | Code refactoring |
+| `test` | Test additions/changes |
+| `docs` | Documentation changes |
+| `chore` | Maintenance tasks |
+| `plan` | Plan commit (planner phase) |

--- a/docs/diagrams/04-code.md
+++ b/docs/diagrams/04-code.md
@@ -1,184 +1,91 @@
-# Code Diagram (L4)
-
-## open-looper Key Implementation Patterns
+# L4 Code Diagram - Key Implementation Patterns
 
 ```mermaid
-C4Component
-    title Code Diagram - Key Patterns and Formats
+C4Code
+  title Open-Looper Code Diagram - Implementation Patterns
 
-    Component_Boundary(patterns, "Implementation Patterns") {
-        Component(agent_def, "Agent Definition Format", "Markdown-based agent specifications")
-        Component(git_trailers, "Git Commit Trailers", "Loop-Phase, Loop-Iteration, Loop-Verdict")
-        Component(worktree_setup, "Worktree Setup", "Git worktree isolation per task")
-        Component(tdd_cycle, "TDD Cycle", "RED → GREEN → SIMPLIFY")
-    }
+  Boundary(core, "Core Loop Pattern") {
+    Component(plan_fn, "plan()", "Function", "Creates plan commit with test descriptions")
+    Component(do_fn, "do()", "Function", "Executes RED→GREEN→SIMPLIFY cycle")
+    Component(check_fn, "check()", "Function", "Runs verification and issues verdict")
+    Component(loop, "while !done", "Loop", "Iterates until checker passes or max iterations")
+  }
 
-    Component_Boundary(formats, "Data Formats") {
-        Component(plan_format, "Plan Format", ".opencode/plans/<task>/iteration-N.md")
-        Component(context_format, "Context Format", "JSON with TASK_NAME, ITERATION, SCRIPTS_DIR")
-        Component(commit_msg, "Commit Message", "type(scope): description body")
-    }
+  Boundary(tdd, "TDD Cycle") {
+    Component(red_phase, "RED Phase", "Phase", "Write failing tests first")
+    Component(green_phase, "GREEN Phase", "Phase", "Implement minimum code to pass")
+    Component(simplify_phase, "SIMPLIFY Phase", "Phase", "Refactor and clean up code")
+  }
 
-    Rel(agent_def, git_trailers, "Uses for auditing")
-    Rel(agent_def, worktree_setup, "Creates isolation")
-    Rel(git_trailers, tdd_cycle, "Tracks phase progression")
-    Rel(plan_format, context_format, "Passes context to agents")
-    Rel(worktree_setup, commit_msg, "Creates conventional commits")
-    Rel(tdd_cycle, commit_msg, "Generates commit messages")
+  Boundary(patterns, "Key Patterns") {
+    Component(subagent_spawn, "Task() spawn", "Pattern", "Launch sub-agents with spec and context")
+    Component(commit_trail, "Commit Trail", "Pattern", "Each phase commits with trailers for traceability")
+    Component(pointer_resolution, "Delta Pointers", "Pattern", "Plans reference prior iterations by hash")
+    Component(skill_discovery, "Skill Discovery", "Pattern", "Load skills via $SCRIPTS_DIR/<name>")
+  }
+
+  Rel(loop, plan_fn, "1. Plan")
+  Rel(loop, do_fn, "2. Do")
+  Rel(loop, check_fn, "3. Check")
+
+  Rel(do_fn, red_phase, "Writes tests")
+  Rel(do_fn, green_phase, "Implements")
+  Rel(do_fn, simplify_phase, "Refactors")
+
+  Rel(red_phase, green_phase, "Commits RED → GREEN")
+  Rel(green_phase, simplify_phase, "Commits GREEN → SIMPLIFY")
+
+  Rel(subagent_spawn, commit_trail, "Metadata in commits")
+  Rel(pointer_resolution, commit_trail, "Hash references")
+  Rel(skill_discovery, commit_trail, "Scripts track state")
+
+  ShowLegend()
 ```
 
-## Pattern 1: Agent Definition Format
+## Implementation Patterns
 
-```markdown
-# Agent Name
+### Core Loop Pattern
+The PDC loop follows a simple but powerful structure:
 
-## Description
-Brief description of agent purpose.
-
-## Mode
-primary | subagent
-
-## Instructions
-Step-by-step instructions...
-
-## Usage
-```bash
-$AGENTS_DIR/<agent-name>
-```
-
-## Examples
-Example invocations...
-```
-
-## Pattern 2: Git Commit Trailers
-
-Commits follow conventional commit format with PDC loop trailers:
-
-```
-type(scope): short description
-
-Longer description of changes made.
-
-Loop-Phase: do-red | do-green | do-simplify | do-integration
-Loop-Iteration: N
-Loop-Verdict: PASS | FAIL (at checker phase)
-```
-
-### Trailer Types
-
-| Trailer | Values | Purpose |
-|---------|--------|---------|
-| **Loop-Phase** | plan, do-red, do-green, do-simplify, do-integration, do-check | Current phase |
-| **Loop-Iteration** | 1, 2, 3, ... | Iteration number |
-| **Loop-Verdict** | PASS, FAIL | Checker verdict (if applicable) |
-
-## Pattern 3: Worktree Setup
-
-```bash
-# Create isolated worktree for task
-setup-worktree --task <task-name> --iteration <N>
-
-# Result: .worktrees/<task-name>/
-# - Isolated git branch per task
-# - No interference with main branch
-# - Easy cleanup on completion
-```
-
-### Worktree Directory Structure
-
-```
-.worktrees/
-└── <task-name>/
-    ├── .git/              # Worktree git data
-    ├── .opencode/         # Agent definitions
-    │   └── agents/
-    ├── docs/              # Documentation
-    └── [project files]    # Task-specific changes
-```
-
-## Pattern 4: TDD Cycle (RED-GREEN-SIMPLIFY)
-
-```
-┌─────────────────────────────────────────┐
-│  RED PHASE                              │
-│  - Write failing test first             │
-│  - Commit: "red: add failing tests"     │
-│  - Loop-Phase: do-red                   │
-└────────────────┬──────────────────────┘
-                 │ Tests fail
-                 ▼
-┌─────────────────────────────────────────┐
-│  GREEN PHASE                            │
-│  - Implement minimal code to pass       │
-│  - Commit: "green: implement feature"   │
-│  - Loop-Phase: do-green                 │
-└────────────────┬──────────────────────┘
-                 │ Tests pass
-                 ▼
-┌─────────────────────────────────────────┐
-│  SIMPLIFY PHASE                         │
-│  - Refine implementation                 │
-│  - Remove redundancy, improve naming    │
-│  - Commit: "simplify: refine impl"      │
-│  - Loop-Phase: do-simplify               │
-└─────────────────────────────────────────┘
-```
-
-## Pattern 5: Plan Format
-
-```markdown
-# Plan: <Task Name>
-
-## Bug Analysis / Feature Description
-...
-
-## Fix Plan / Implementation Plan
-...
-
-## Files to modify
-...
-
-## Tests
-...
-
-## Acceptance Criteria
-...
-
-Loop-Phase: plan
-Loop-Iteration: N
-```
-
-## Pattern 6: Agent Context (JSON)
-
-```json
-{
-  "TASK_NAME": "add-authentication",
-  "ITERATION": 1,
-  "MAX_ITERATIONS": 5,
-  "SCRIPTS_DIR": "/path/to/.opencode/scripts",
-  "AGENTS_DIR": "/path/to/.opencode/agents",
-  "WORKTREE_DIR": "/path/to/.worktrees/add-authentication"
+```javascript
+async function runLoop(task, maxIterations = 10) {
+  for (let i = 1; i <= maxIterations; i++) {
+    const plan = await planner.createPlan(task, i);
+    await doer.execute(plan, i);
+    const verdict = await checker.verify(plan, i);
+    if (verdict === 'PASS') break;
+  }
 }
 ```
 
-## Pattern 7: Conventional Commit Format
+### TDD Cycle (RED→GREEN→REFACTOR)
+1. **RED** - Write failing tests derived from acceptance criteria
+2. **GREEN** - Write minimum implementation to pass tests
+3. **SIMPLIFY** - Refactor without changing behavior
 
+### Sub-Agent Spawning Pattern
+```javascript
+Task(subagent_type="explore", prompt="<task-spec>", task_id?)
 ```
-<type>(<scope>): <short description>
+- Each sub-agent receives task description, context, and success criteria
+- Results returned synchronously unless `run_in_background=true`
 
-[optional body]
-
-[optional trailers]
+### Commit Trail Pattern
+Each phase commits with trailers for traceability:
+```
+Loop-Phase: do-red
+Loop-Iteration: 3
 ```
 
-### Commit Types
+### Delta Pointer Resolution
+Plans can reference prior iterations:
+```
+(unchanged from iteration 2 — see abc1234)
+```
+Resolved via `git log <hash> -1 --format="%B"`
 
-| Type | Description |
-|------|-------------|
-| `feat` | New feature |
-| `fix` | Bug fix |
-| `refactor` | Code refactoring |
-| `test` | Test additions/changes |
-| `docs` | Documentation changes |
-| `chore` | Maintenance tasks |
-| `plan` | Plan commit (planner phase) |
+### Skill Discovery
+Scripts discovered and invoked via:
+```bash
+$SCRIPTS_DIR/<skill-name> [--args]
+```

--- a/docs/diagrams/index.md
+++ b/docs/diagrams/index.md
@@ -1,0 +1,109 @@
+# open-looper C4 Architecture Diagrams
+
+This directory contains C4 architecture diagrams documenting the open-looper system.
+
+## Diagram Overview
+
+| Level | Diagram | Purpose |
+|-------|---------|---------|
+| **L1** | [01-context.md](./01-context.md) | System context — external actors and interactions |
+| **L2** | [02-container.md](./02-container.md) | Container architecture — 4 main containers |
+| **L3** | [03-component.md](./03-component.md) | Component internals — agents and scripts |
+| **L4** | [04-code.md](./04-code.md) | Code patterns — key implementation formats |
+
+## Quick Reference
+
+### External Actors
+- **User** — Issues `/looper <task>` commands
+- **GitHub** — Repository, CI/CD, Pull Requests
+- **Docker** — Integration test runtime
+- **Git** — Version control with worktree support
+
+### Core Containers
+1. **OpenCode Plugin** — OpenCode platform with looper skill
+2. **Agents Container** — Planner, Doer, Checker + subagents
+3. **Scripts Container** — Git, Docker, Stack helper scripts
+4. **Worktrees Container** — Git worktree isolation per task
+
+### PDC Loop Phases
+```
+PLAN → RED → GREEN → SIMPLIFY → (INTEGRATION) → CHECK
+           ↓
+        [iterate until PASS]
+```
+
+### Key Technologies
+| Component | Technology |
+|-----------|------------|
+| Agent Definitions | Markdown (`.md`) |
+| Scripting | Bash, Node.js |
+| Version Control | Git with worktrees |
+| Container Runtime | Docker, docker-compose |
+| Communication | OpenCode Task tool |
+
+## Diagram Relationships
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ L1: Context — External actors (User, GitHub, Docker)     │
+│    ↓                                                    │
+│ L2: Container — 4 containers (Agents, Scripts, Plugin,   │
+│              Worktrees)                                 │
+│    ↓                                                    │
+│ L3: Component — Agent internals (Planner, Doer,        │
+│              Checker) + Script libraries                │
+│    ↓                                                    │
+│ L4: Code — Implementation patterns (formats, trailers, │
+│          TDD cycle)                                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Viewing Diagrams
+
+These diagrams use **Mermaid** syntax and are compatible with:
+
+- GitHub Markdown (rendered via github.com)
+- GitLab Markdown (rendered via gitlab.com)
+- VS Code Mermaid extension
+- [Mermaid Live Editor](https://mermaid.live)
+
+### Render Example
+
+````markdown
+```mermaid
+C4Context
+    title Context Diagram
+    ...
+```
+````
+
+## Legend
+
+| C4 Element | Description |
+|-----------|-------------|
+| `Person` | Human actor |
+| `Container` | Application or data store |
+| `Component` | Internal component of a container |
+| `System_Ext` | External system |
+| `Enterprise_Boundary` | Groups elements of same platform |
+| `Container_Boundary` | Groups elements of same container |
+| `Component_Boundary` | Groups elements of same component |
+
+## Maintenance
+
+When modifying the system:
+
+1. Update **L4** (code patterns) for implementation changes
+2. Update **L3** (components) for structural changes
+3. Update **L2** (containers) for container-level changes
+4. Update **L1** (context) for external actor changes
+
+## Files
+
+| File | Lines | Description |
+|------|-------|-------------|
+| `index.md` | This file | Overview and navigation |
+| `01-context.md` | ~60 | Context diagram (L1) |
+| `02-container.md` | ~90 | Container diagram (L2) |
+| `03-component.md` | ~120 | Component diagram (L3) |
+| `04-code.md` | ~180 | Code diagram (L4) |

--- a/docs/diagrams/index.md
+++ b/docs/diagrams/index.md
@@ -1,109 +1,30 @@
-# open-looper C4 Architecture Diagrams
+# Open-Looper Architecture Diagrams
 
 This directory contains C4 architecture diagrams documenting the open-looper system.
 
-## Diagram Overview
+## Diagram Index
 
-| Level | Diagram | Purpose |
-|-------|---------|---------|
-| **L1** | [01-context.md](./01-context.md) | System context — external actors and interactions |
-| **L2** | [02-container.md](./02-container.md) | Container architecture — 4 main containers |
-| **L3** | [03-component.md](./03-component.md) | Component internals — agents and scripts |
-| **L4** | [04-code.md](./04-code.md) | Code patterns — key implementation formats |
-
-## Quick Reference
-
-### External Actors
-- **User** — Issues `/looper <task>` commands
-- **GitHub** — Repository, CI/CD, Pull Requests
-- **Docker** — Integration test runtime
-- **Git** — Version control with worktree support
-
-### Core Containers
-1. **OpenCode Plugin** — OpenCode platform with looper skill
-2. **Agents Container** — Planner, Doer, Checker + subagents
-3. **Scripts Container** — Git, Docker, Stack helper scripts
-4. **Worktrees Container** — Git worktree isolation per task
-
-### PDC Loop Phases
-```
-PLAN → RED → GREEN → SIMPLIFY → (INTEGRATION) → CHECK
-           ↓
-        [iterate until PASS]
-```
-
-### Key Technologies
-| Component | Technology |
-|-----------|------------|
-| Agent Definitions | Markdown (`.md`) |
-| Scripting | Bash, Node.js |
-| Version Control | Git with worktrees |
-| Container Runtime | Docker, docker-compose |
-| Communication | OpenCode Task tool |
-
-## Diagram Relationships
-
-```
-┌─────────────────────────────────────────────────────────┐
-│ L1: Context — External actors (User, GitHub, Docker)     │
-│    ↓                                                    │
-│ L2: Container — 4 containers (Agents, Scripts, Plugin,   │
-│              Worktrees)                                 │
-│    ↓                                                    │
-│ L3: Component — Agent internals (Planner, Doer,        │
-│              Checker) + Script libraries                │
-│    ↓                                                    │
-│ L4: Code — Implementation patterns (formats, trailers, │
-│          TDD cycle)                                     │
-└─────────────────────────────────────────────────────────┘
-```
-
-## Viewing Diagrams
-
-These diagrams use **Mermaid** syntax and are compatible with:
-
-- GitHub Markdown (rendered via github.com)
-- GitLab Markdown (rendered via gitlab.com)
-- VS Code Mermaid extension
-- [Mermaid Live Editor](https://mermaid.live)
-
-### Render Example
-
-````markdown
-```mermaid
-C4Context
-    title Context Diagram
-    ...
-```
-````
+| Level | Diagram | Description |
+|-------|---------|-------------|
+| L1 | [01-context.md](./01-context.md) | Context Diagram - External actors and system boundaries |
+| L2 | [02-container.md](./02-container.md) | Container Diagram - Major architectural components |
+| L3 | [03-component.md](./03-component.md) | Component Diagram - Internal structure of containers |
+| L4 | [04-code.md](./04-code.md) | Code Diagram - Key implementation patterns |
 
 ## Legend
 
-| C4 Element | Description |
-|-----------|-------------|
-| `Person` | Human actor |
-| `Container` | Application or data store |
-| `Component` | Internal component of a container |
-| `System_Ext` | External system |
-| `Enterprise_Boundary` | Groups elements of same platform |
-| `Container_Boundary` | Groups elements of same container |
-| `Component_Boundary` | Groups elements of same component |
+```mermaid
+C4Context
+  boundary(OpenLooper, "Open-Looper System") {
+    Person(user, "User", "Human developer using the system")
+    System(looper, "Open-Looper", "AI-powered development loop orchestration")
+  }
+  Rel(user, looper, "Uses", "CLI/GUI")
+```
 
-## Maintenance
+## Quick Reference
 
-When modifying the system:
-
-1. Update **L4** (code patterns) for implementation changes
-2. Update **L3** (components) for structural changes
-3. Update **L2** (containers) for container-level changes
-4. Update **L1** (context) for external actor changes
-
-## Files
-
-| File | Lines | Description |
-|------|-------|-------------|
-| `index.md` | This file | Overview and navigation |
-| `01-context.md` | ~60 | Context diagram (L1) |
-| `02-container.md` | ~90 | Container diagram (L2) |
-| `03-component.md` | ~120 | Component diagram (L3) |
-| `04-code.md` | ~180 | Code diagram (L4) |
+- **L1 Context** - Shows external actors (User, GitHub, Docker, OpenCode) interacting with the system
+- **L2 Container** - Breaks down the system into 4 primary containers (Agents, Scripts, Plugin, Worktrees)
+- **L3 Component** - Details the internal structure of Agents and Script libraries
+- **L4 Code** - Illustrates key implementation patterns and code organization


### PR DESCRIPTION
## Summary
- Adds the `looper-bug-reporter` subagent to report looper-related bugs discovered during PDC loop operations
- Fire-and-forget agent that files issues to `code-salad/open-looper` without blocking the caller

## What this agent does

The `looper-bug-reporter` is invoked when PDC loop agents (checker, debugger, etc.) encounter bugs in the looper codebase itself rather than in user code. It:

1. Checks for duplicate issues before creating
2. Gathers context from up to 3 relevant files
3. Creates a structured bug report with canonical sections (Steps to Reproduce, Expected/Actual Behavior, Environment)
4. Reports back with issue number and URL

## Integration

This agent is called by:
- `looper-checker.md` — when adversarial testing finds a bug
- `looper-check-build.md` — when typecheck/build fails unexpectedly
- `looper-check-runtime.md` — when runtime behavior is incorrect
- `looper-debugger.md` — when root cause is a looper bug

## Files added
- `.opencode/agents/looper-bug-reporter.md` — the agent definition