### PR TITLE
feat: add yolobox backend for opencode sandboxing

### DIFF
--- a/.opencode/scripts/backends/README.md
+++ b/.opencode/scripts/backends/README.md
@@ -1,0 +1,74 @@
+# Sandbox Backend Adapters
+
+This directory contains pluggable backend scripts for `run-sandboxed`. Each
+file `<name>.sh` is a self-contained adapter that the dispatcher selects via
+`LOOPER_SANDBOX_BACKEND=<name>`.
+
+## Backend contract
+
+### Environment variables (guaranteed set by the dispatcher before `exec`)
+
+| Variable | Description |
+|---|---|
+| `LOOPER_SANDBOX_TASK` | Full task string from `$*`, spaces preserved |
+| `LOOPER_SANDBOX_NAME` | Unique per invocation: `loop-$(date +%s)-$$` |
+| `LOOPER_SANDBOX_BACKEND` | Resolved backend name (always set explicitly) |
+| `LOOPER_SANDBOX_IMAGE` | Container image ref (default: `ghcr.io/code-salad/looper-sandbox:latest`) |
+| `LOOPER_SANDBOX_POLICY` | Isolation policy (default: `balanced`; used by sbx only) |
+| `ANTHROPIC_API_KEY` | Required; already validated by the dispatcher |
+| `GITHUB_TOKEN` | May be empty string (warn-only; dispatcher emits the warning) |
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Inner command succeeded |
+| `127` | Required backend CLI is not installed on PATH |
+| `*` | Inner command exit code passed through verbatim |
+
+### Each backend MUST
+
+- Check its required CLI is present; exit 127 with an install hint if not.
+- Install a cleanup trap on `INT`/`TERM`/`EXIT` that removes its own resources
+  (container, sandbox, worktree) — the trap must be idempotent.
+- Stream `stdout`/`stderr` from the inner `claude` invocation through unmodified.
+- Exit with the inner command's exit code.
+
+### Each backend MUST NOT
+
+- Read positional arguments — everything arrives via environment variables.
+- Touch files outside `$(pwd)` or its own scratch area.
+- Print banner or progress output on `stderr` that would clobber the loop's own output.
+- Redefine `LOOPER_SANDBOX_*` or `ANTHROPIC_API_KEY` — treat them as read-only.
+
+## Backends shipped in v1
+
+| File | Backend name | Notes |
+|---|---|---|
+| `docker.sh` | `docker` | DooD via `/var/run/docker.sock` |
+| `sbx.sh` | `sbx` | microVM via `sbx` CLI; requires KVM |
+| `yolobox.sh` | `yolobox` | Yolobox sandbox with Docker-in-Docker and opencode |
+| `null.sh` | `null` | Runs opencode directly on the host; reference implementation |
+
+The `null` backend is intentionally not exposed through the
+`/looper:looper-sandboxed` skill (which gates on `docker|sbx` in Phase 1).
+It is reachable only via direct `run-sandboxed` invocation, making it useful
+for CI test harnesses and local development without a container runtime.
+
+## How to add a backend
+
+1. Create `backends/<name>.sh` with `#!/usr/bin/env bash` and `set -euo pipefail`.
+2. Read `LOOPER_SANDBOX_TASK`, `LOOPER_SANDBOX_NAME`, and any other contract
+   variables you need from the environment — do not accept positional args.
+3. Check that your required CLI is on PATH; emit an install hint and exit 127
+   if it is not.
+4. Install a cleanup trap (EXIT INT TERM) that removes any resources your
+   backend creates, keyed on `LOOPER_SANDBOX_NAME` so parallel runs stay
+   isolated.
+5. Run `claude -p "/looper:loop $LOOPER_SANDBOX_TASK"` (or equivalent) inside
+   your isolation environment, forwarding `ANTHROPIC_API_KEY` and
+   `GITHUB_TOKEN`.
+6. Exit with the inner command's exit code.
+7. Make the script executable (`chmod +x`) and run `shellcheck` on it — CI
+   enforces both.
+8. Add a row to the table above in this README.

--- a/.opencode/scripts/backends/yolobox.sh
+++ b/.opencode/scripts/backends/yolobox.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+YOLOBOX_BIN="${HOME}/.local/bin/yolobox"
+
+if ! command -v "$YOLOBOX_BIN" >/dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: 'yolobox' is not installed (LOOPER_SANDBOX_BACKEND=yolobox).
+Install from: https://github.com/finbarr/yolobox
+  curl -fsSL https://raw.githubusercontent.com/finbarr/yolobox/master/install.sh | bash
+EOF
+    exit 127
+fi
+
+WORKTREE_DIR="$(pwd)"
+GIT_DIR="$WORKTREE_DIR/.git"
+
+# Yolobox mounts the worktree at the same path as the host.
+# The worktree's .git file points to the host's .git directory.
+# We need to mount the host's .git at the same path inside the container
+# so git worktree references resolve correctly.
+GIT_MOUNT_PATH="$(dirname "$GIT_DIR")"
+
+# Build yolobox command with proper mounts for git worktree
+YOLOBOX_CMD="$YOLOBOX_BIN run \
+    --docker \
+    --gh-token \
+    --mount ${GIT_DIR}:${GIT_DIR}"
+
+# Run opencode with the task
+# opencode run executes the agent with the given message
+exec bash -c "$YOLOBOX_CMD -- opencode run \"$LOOPER_SANDBOX_TASK\""

--- a/scripts/worktree-agent.sh
+++ b/scripts/worktree-agent.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -e
+
+AGENT_ID="${AGENT_ID:-$$}"
+WORKTREE_DIR="/tmp/wt-agent-${AGENT_ID}"
+PROJECT_PATH="/home/ubuntu/open-looper"
+YOLOBOX_BIN="${HOME}/.local/bin/yolobox"
+
+usage() {
+    cat <<EOF
+Usage: $0 [command]
+
+Commands:
+  create <branch-name>   Create worktree and start yolobox with opencode
+  shell                 Start yolobox shell in existing worktree
+  done                  Remove worktree and cleanup
+  status                Show worktree status
+
+Examples:
+  AGENT_ID=1 $0 create issue-123
+  AGENT_ID=1 $0 shell
+  AGENT_ID=1 $0 done
+  $0 status
+EOF
+    exit 1
+}
+
+cmd_create() {
+    local branch="${1:-agent-$AGENT_ID}"
+
+    echo "=== Creating worktree ==="
+    echo "Worktree dir: ${WORKTREE_DIR}"
+    echo "Branch: ${branch}"
+
+    # Create worktree (fast! ~17ms)
+    cd "$PROJECT_PATH"
+    if git worktree list | grep -q "$WORKTREE_DIR"; then
+        echo "Worktree already exists, removing first..."
+        git worktree remove "$WORKTREE_DIR" 2>/dev/null || rm -rf "$WORKTREE_DIR"
+    fi
+
+    git worktree add "$WORKTREE_DIR" -b "$branch"
+    echo "Worktree created!"
+
+    # The worktree's .git file points to the host's .git/worktrees/<name>
+    # When yolobox mounts the worktree, we need to mount the host .git dir
+    # at /home/ubuntu/open-looper/.git to make git work inside the container
+    echo "=== Git file (do not modify) ==="
+    cat "$WORKTREE_DIR/.git"
+
+    echo ""
+    echo "=== Starting yolobox ==="
+    cmd_shell
+}
+
+cmd_shell() {
+    if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "Error: Worktree doesn't exist at ${WORKTREE_DIR}"
+        echo "Run '$0 create <branch>' first"
+        exit 1
+    fi
+
+    # Ensure we're in the worktree directory for yolobox to pick it up
+    cd "$WORKTREE_DIR"
+
+    echo "Starting yolobox..."
+    echo "Worktree: ${WORKTREE_DIR}"
+    echo "Branch: $(git -C "$WORKTREE_DIR" branch --show-current)"
+    echo ""
+
+    # Key insight: Mount the host's .git directory at /home/ubuntu/open-looper/.git
+    # This makes the git worktree references work inside the container
+    # Yolobox automatically mounts the worktree at /home/ubuntu/open-looper
+    "$YOLOBOX_BIN" run \
+        --docker \
+        --gh-token \
+        --mount "/home/ubuntu/open-looper/.git:/home/ubuntu/open-looper/.git" \
+        -- opencode
+}
+
+cmd_done() {
+    if [ ! -d "$WORKTREE_DIR" ]; then
+        echo "No worktree to remove"
+        return
+    fi
+
+    echo "=== Cleaning up ==="
+    cd "$WORKTREE_DIR"
+
+    if git diff --quiet 2>/dev/null && git diff --cached --quiet 2>/dev/null; then
+        echo "No uncommitted changes"
+    else
+        echo "Warning: uncommitted changes exist:"
+        git status --short
+        echo "Remove manually with: rm -rf ${WORKTREE_DIR}"
+        return
+    fi
+
+    cd "$PROJECT_PATH"
+    if git worktree remove "$WORKTREE_DIR" 2>/dev/null; then
+        echo "Worktree removed"
+    else
+        rm -rf "$WORKTREE_DIR"
+        echo "Removed manually"
+    fi
+}
+
+cmd_status() {
+    echo "=== Worktree Agent Status ==="
+    echo "Agent ID: ${AGENT_ID}"
+    echo "Worktree dir: ${WORKTREE_DIR}"
+    echo "Exists: $([ -d "$WORKTREE_DIR" ] && echo 'yes' || echo 'no')"
+    echo ""
+
+    if [ -d "$WORKTREE_DIR" ]; then
+        echo "=== Git Status ==="
+        cd "$WORKTREE_DIR" && git status --short 2>/dev/null || echo "Not a git repo"
+        echo ""
+        echo "=== Branch ==="
+        cd "$WORKTREE_DIR" && git branch --show-current 2>/dev/null || echo "N/A"
+    fi
+
+    echo ""
+    echo "=== All Worktrees ==="
+    cd "$PROJECT_PATH" && git worktree list 2>/dev/null || echo "N/A"
+}
+
+CMD="${1:-help}"
+shift 2>/dev/null || true
+
+case "$CMD" in
+    create|shell|done|status)
+        "cmd_$CMD" "$@"
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary

Add yolobox backend for opencode sandboxing.

- Yolobox provides Docker-in-Docker and proper git worktree isolation
- Mount host .git at same path so worktree references resolve
- Add worktree-agent.sh helper script for standalone use

## Files
-  — sandbox backend
-  — backend documentation
- Usage: scripts/worktree-agent.sh [command]

Commands:
  create <branch-name>   Create worktree and start yolobox with opencode
  shell                 Start yolobox shell in existing worktree
  done                  Remove worktree and cleanup
  status                Show worktree status

Examples:
  AGENT_ID=1 scripts/worktree-agent.sh create issue-123
  AGENT_ID=1 scripts/worktree-agent.sh shell
  AGENT_ID=1 scripts/worktree-agent.sh done
  scripts/worktree-agent.sh status — standalone worktree helper