### PR TITLE
fix(orchestrator): remove --all-match from verdict search

### DIFF
--- a/.opencode/agents/looper-simplified.md
+++ b/.opencode/agents/looper-simplified.md
@@ -230,7 +230,7 @@ MAX_ROUNDS: $MAX_ROUNDS") 2>&1) && REVIEW_EXIT=0 || REVIEW_EXIT=$?
 
     # Read verdict from reviewer commit (written via git-commit-loop with --verdict)
     cd "$CLONE_DIR"
-    VERDICT=$(git log --grep="Loop-Verdict:" --all-match --format="%B" -1 2>/dev/null \
+    VERDICT=$(git log --grep="Loop-Verdict:" --format="%B" -1 2>/dev/null \
         | grep -oE 'Loop-Verdict: (PASS|FAIL)' | tail -1 | sed 's/Loop-Verdict: //' || echo "")
 
     echo "[looper] Round $ROUND verdict: $VERDICT" >&2


### PR DESCRIPTION
## Problem / Task

The orchestrator verdict search pattern was never matching because the `--all-match` flag was incorrectly used with `git log --grep`.

**Current behavior:** `git log --grep="Loop-Verdict:" --all-match --format="%B" -1` with `--all-match` requires ALL grep patterns to match on the same line, but the verdict is on a separate trailer line from the commit message body, so the search never finds commits.

**Expected behavior:** Remove `--all-match` so the grep search can find commits where "Loop-Verdict:" appears on any line in the commit message body.

## Existing Architecture

The looper-simplified orchestrator reads the review verdict from the most recent commit's message:

```mermaid
flowchart TD
    A[Reviewer Subagent] -->|Writes verdict commit| B[git-commit-loop --verdict PASS/FAIL]
    B --> C[(Commit with Loop-Verdict trailer)]
    C --> D[Orchestrator reads verdict]
    D -->|grep search| C
    
    subgraph "looper-simplified.md line 233"
        E["git log --grep='Loop-Verdict:' --all-match ..."]
    end
```

**Bug:** `--all-match` requires all `--grep` patterns to match the same line. Since "Loop-Verdict:" is on a different line than the commit subject, the search never finds any commits.

## Proposed Architecture

Remove `--all-match` from the verdict grep search so it can match any line containing "Loop-Verdict:" in the commit message:

```mermaid
flowchart TD
    A[Reviewer Subagent] -->|Writes verdict commit| B[git-commit-loop --verdict PASS/FAIL]
    B --> C[(Commit with Loop-Verdict trailer)]
    C --> D[Orchestrator reads verdict]
    D -->|grep search (no --all-match)| C
```

## Key Changes

- **`.opencode/agents/looper-simplified.md` line 233:** Removed `--all-match` flag from `git log --grep` command
  - Before: `git log --grep="Loop-Verdict:" --all-match --format="%B" -1`
  - After: `git log --grep="Loop-Verdict:" --format="%B" -1`

## Tests & Checks

| Check | Status | Details |
|-------|--------|---------|
| Unit Tests (bats) | ✅ | 23 tests passed |
| Lint | ⏭️ | No linter detected |
| Build | ⏭️ | N/A (bash project) |